### PR TITLE
fall back to user socket

### DIFF
--- a/crates/agentdesktop/src/main.rs
+++ b/crates/agentdesktop/src/main.rs
@@ -31,9 +31,9 @@ const TRAY_OFFLINE_ICON: &[u8] =
 #[derive(Parser)]
 #[command(about = "Agent Desktop UI, daemon, and command-line tools")]
 struct Args {
-    /// Local endpoint exposed by the daemon (Unix socket or Windows named pipe).
-    #[arg(long, default_value = DEFAULT_SOCKET_PATH, global = true)]
-    socket: PathBuf,
+    /// Override the local endpoint exposed by the daemon (Unix socket or Windows named pipe).
+    #[arg(long, global = true)]
+    socket: Option<PathBuf>,
 
     #[command(subcommand)]
     command: Option<Command>,
@@ -417,14 +417,20 @@ fn run_desktop() -> anyhow::Result<()> {
     Ok(())
 }
 
-fn run_command(command: Command, socket: PathBuf) -> anyhow::Result<()> {
+fn run_command(command: Command, socket: Option<PathBuf>) -> anyhow::Result<()> {
     tokio::runtime::Builder::new_multi_thread()
         .enable_all()
         .build()?
         .block_on(async move {
             match command {
-                Command::Daemon(args) => daemon::run(*args, socket).await,
-                Command::Client(command) => cli::run(command, socket).await,
+                Command::Daemon(args) => {
+                    let socket = socket.unwrap_or_else(|| DEFAULT_SOCKET_PATH.into());
+                    daemon::run(*args, socket).await
+                }
+                Command::Client(command) => {
+                    let socket = socket.unwrap_or_else(socket_path);
+                    cli::run(command, socket).await
+                }
             }
         })
 }

--- a/crates/client/src/lib.rs
+++ b/crates/client/src/lib.rs
@@ -17,11 +17,18 @@ type LocalStream = UnixStream;
 #[cfg(windows)]
 type LocalStream = NamedPipeClient;
 
+fn connect_error(endpoint: &Path) -> String {
+    format!(
+        "connect to {}\nCheck that the Agentdesktop daemon is running.",
+        endpoint.display()
+    )
+}
+
 #[cfg(unix)]
 async fn connect(endpoint: &Path) -> anyhow::Result<LocalStream> {
     UnixStream::connect(endpoint)
         .await
-        .with_context(|| format!("connect to {}", endpoint.display()))
+        .with_context(|| connect_error(endpoint))
 }
 
 #[cfg(windows)]
@@ -37,7 +44,7 @@ async fn connect(endpoint: &Path) -> anyhow::Result<LocalStream> {
                 tokio::time::sleep(std::time::Duration::from_millis(50)).await;
             }
             Err(error) => {
-                return Err(error).with_context(|| format!("connect to {}", endpoint.display()));
+                return Err(error).with_context(|| connect_error(endpoint));
             }
         }
     }
@@ -119,4 +126,21 @@ where
         );
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::Path;
+
+    use super::connect_error;
+
+    #[test]
+    fn connection_error_suggests_checking_the_daemon() {
+        let endpoint = Path::new("/tmp/agentdesktop.sock");
+
+        assert_eq!(
+            connect_error(endpoint),
+            "connect to /tmp/agentdesktop.sock\nCheck that the Agentdesktop daemon is running."
+        );
+    }
 }

--- a/crates/controller/src/admin.rs
+++ b/crates/controller/src/admin.rs
@@ -17,6 +17,7 @@ use agentdesktop_core::config::DaemonConfig;
 use crate::{
     daemon_config::DaemonConfigStore,
     database::{Database, DeviceDetail, DeviceSummary},
+    gateway_jwt::{self, GatewayJwks},
 };
 
 #[derive(Clone)]
@@ -63,7 +64,11 @@ struct Overview {
     recent_devices: Vec<DeviceSummary>,
 }
 
-pub async fn serve(address: SocketAddr, state: AdminState) -> anyhow::Result<()> {
+pub async fn serve(
+    address: SocketAddr,
+    state: AdminState,
+    gateway_jwks: Option<GatewayJwks>,
+) -> anyhow::Result<()> {
     let app = Router::new()
         .route("/api/v1/overview", get(overview))
         .route("/api/v1/devices", get(devices))
@@ -74,7 +79,8 @@ pub async fn serve(address: SocketAddr, state: AdminState) -> anyhow::Result<()>
         )
         .route("/api/v1/settings", get(settings))
         .fallback(get(asset))
-        .with_state(state);
+        .with_state(state)
+        .merge(gateway_jwt::routes(gateway_jwks));
     let listener = tokio::net::TcpListener::bind(address).await?;
     info!(listen = %address, "controller admin UI listening");
     axum::serve(listener, app).await?;

--- a/crates/controller/src/main.rs
+++ b/crates/controller/src/main.rs
@@ -70,6 +70,7 @@ async fn main() -> anyhow::Result<()> {
         tracing::info!("inference gateway JWT issuance enabled");
     }
     let gateway_jwks = gateway_jwt_issuer.as_ref().map(GatewayJwtIssuer::jwks);
+    let admin_gateway_jwks = gateway_jwks.clone();
     let admin_state = AdminState::new(
         database.clone(),
         daemon_config.clone(),
@@ -131,7 +132,7 @@ async fn main() -> anyhow::Result<()> {
             .await
             .context("serve fleet gRPC API")
     };
-    let admin = admin::serve(admin_listen, admin_state);
+    let admin = admin::serve(admin_listen, admin_state, admin_gateway_jwks);
     tokio::try_join!(fleet, admin)?;
     Ok(())
 }

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -10,10 +10,34 @@ pub const DEFAULT_CONTROLLER_CONFIG_PATH: &str = "/etc/agentdesktop/controller.y
 /// Default directory for the device identity and other persistent daemon state.
 pub const DEFAULT_STATE_DIR: &str = "/var/lib/agentdesktop";
 
-#[cfg(unix)]
+#[cfg(all(unix, not(target_os = "macos")))]
 /// Default Unix socket exposed by the daemon to local clients.
 pub const DEFAULT_SOCKET_PATH: &str = "/run/agentdesktop/agentdesktop.sock";
+
+#[cfg(target_os = "macos")]
+/// Default Unix socket exposed by the daemon to local clients.
+pub const DEFAULT_SOCKET_PATH: &str = "/var/run/agentdesktop/agentdesktop.sock";
 
 #[cfg(windows)]
 /// Default Windows named pipe exposed by the daemon to local clients.
 pub const DEFAULT_SOCKET_PATH: &str = r"\\.\pipe\agentdesktop";
+
+#[cfg(test)]
+mod tests {
+    use super::DEFAULT_SOCKET_PATH;
+
+    #[test]
+    fn default_socket_uses_platform_runtime_directory() {
+        #[cfg(target_os = "macos")]
+        assert_eq!(
+            DEFAULT_SOCKET_PATH,
+            "/var/run/agentdesktop/agentdesktop.sock"
+        );
+
+        #[cfg(all(unix, not(target_os = "macos")))]
+        assert_eq!(DEFAULT_SOCKET_PATH, "/run/agentdesktop/agentdesktop.sock");
+
+        #[cfg(windows)]
+        assert_eq!(DEFAULT_SOCKET_PATH, r"\\.\pipe\agentdesktop");
+    }
+}

--- a/examples/claude/README.md
+++ b/examples/claude/README.md
@@ -2,47 +2,25 @@
 
 This scenario runs Agentdesktop with Dex, Claude Code, and Agentgateway.
 
-Generate all local controller key material in one directory. The TLS directory
-shorthand recognizes `controller.pem`, `controller-key.pem`, `device-ca.pem`,
-and `device-ca-key.pem`; the same directory also holds the inference-gateway
-JWT signing key:
+From the repository root, generate the development TLS and JWT keys used by the
+checked-in configuration:
 
 ```console
-mkdir -p /tmp/agentdesktop-keys
-
-openssl genpkey -algorithm RSA -pkeyopt rsa_keygen_bits:2048 \
-  -out /tmp/agentdesktop-keys/gateway-jwt-key.pem
-
-openssl req -x509 -newkey ec -pkeyopt ec_paramgen_curve:P-256 -nodes \
-  -keyout /tmp/agentdesktop-keys/device-ca-key.pem \
-  -out /tmp/agentdesktop-keys/device-ca.pem \
-  -days 365 -sha256 -subj /CN=Agentdesktop-local-device-CA \
-  -addext basicConstraints=critical,CA:TRUE \
-  -addext keyUsage=critical,keyCertSign,cRLSign
-
-openssl req -new -newkey ec -pkeyopt ec_paramgen_curve:P-256 -nodes \
-  -keyout /tmp/agentdesktop-keys/controller-key.pem \
-  -out /tmp/agentdesktop-controller.csr \
-  -subj /CN=localhost \
-  -addext subjectAltName=DNS:localhost,IP:127.0.0.1 \
-  -addext extendedKeyUsage=serverAuth
-
-openssl x509 -req -in /tmp/agentdesktop-controller.csr \
-  -CA /tmp/agentdesktop-keys/device-ca.pem \
-  -CAkey /tmp/agentdesktop-keys/device-ca-key.pem \
-  -set_serial 1 -days 30 -sha256 -copy_extensions copy \
-  -out /tmp/agentdesktop-keys/controller.pem
-
-rm /tmp/agentdesktop-controller.csr
-chmod 600 /tmp/agentdesktop-keys/controller-key.pem \
-  /tmp/agentdesktop-keys/device-ca-key.pem \
-  /tmp/agentdesktop-keys/gateway-jwt-key.pem
+./examples/claude/create-keys.sh
 ```
+
+The script creates five files under `/tmp/agentdesktop-keys`: the controller
+certificate and private key, the device CA certificate and private key, and the
+gateway JWT signing key. It refuses to overwrite an existing key set.
 
 Start Dex:
 
 ```console
 docker compose -f examples/claude/compose.yaml up -d dex
+curl --fail --silent --show-error \
+  --retry 10 --retry-all-errors --retry-delay 1 \
+  http://127.0.0.1:5556/dex/.well-known/openid-configuration \
+  > /dev/null
 ```
 
 Start the controller:
@@ -53,9 +31,19 @@ agentdesktop-controller --config examples/claude/controller.yaml
 
 Start Agentgateway:
 
+On Docker Desktop, first enable host networking under **Settings > Resources >
+Network**. Linux supports host networking directly.
+
 ```console
- export ANTHROPIC_API_KEY=...
+export ANTHROPIC_API_KEY=...
 docker compose -f examples/claude/compose.yaml up -d agentgateway
+```
+
+Confirm that Agentgateway remains running and answers its reachability route:
+
+```console
+docker compose -f examples/claude/compose.yaml ps agentgateway
+curl --fail --head http://127.0.0.1:4000/
 ```
 
 Run the installed local daemon. Typically, this would run on a different
@@ -81,3 +69,12 @@ agentdesktop
 
 Now that agentdesktop is running, Claude Code can be run.
 It will show the configured `Managed by Agentdesktop` and direct traffic through the gateway.
+
+## Stop the scenario
+
+Stop the foreground daemon and controller with Ctrl-C, then stop Dex and
+Agentgateway:
+
+```console
+docker compose -f examples/claude/compose.yaml down
+```

--- a/examples/claude/create-keys.sh
+++ b/examples/claude/create-keys.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+key_dir=/tmp/agentdesktop-keys
+key_files=(
+  controller.pem
+  controller-key.pem
+  device-ca.pem
+  device-ca-key.pem
+  gateway-jwt-key.pem
+)
+
+if ! command -v openssl >/dev/null 2>&1; then
+  echo "openssl is required to generate Agentdesktop development keys." >&2
+  exit 1
+fi
+
+existing_keys=0
+for file in "${key_files[@]}"; do
+  if [[ -e "${key_dir}/${file}" ]]; then
+    existing_keys=$((existing_keys + 1))
+  fi
+done
+
+if (( existing_keys > 0 )); then
+  if (( existing_keys != ${#key_files[@]} )); then
+    echo "${key_dir} contains an incomplete Agentdesktop development key set." >&2
+    echo "Remove the directory before generating a new key set." >&2
+    exit 1
+  fi
+  echo "${key_dir} already contains Agentdesktop development keys." >&2
+  echo "Remove the directory before generating a new key set." >&2
+  exit 1
+fi
+
+work_dir="$(mktemp -d)"
+trap 'rm -rf "${work_dir}"' EXIT
+
+openssl genpkey -algorithm RSA -pkeyopt rsa_keygen_bits:2048 \
+  -out "${work_dir}/gateway-jwt-key.pem"
+
+cat > "${work_dir}/ca.cnf" <<'EOF'
+[req]
+distinguished_name = subject
+x509_extensions = v3_ca
+prompt = no
+
+[subject]
+CN = Agentdesktop-local-device-CA
+
+[v3_ca]
+basicConstraints = critical,CA:TRUE
+keyUsage = critical,keyCertSign,cRLSign
+subjectKeyIdentifier = hash
+authorityKeyIdentifier = keyid:always,issuer
+EOF
+
+openssl req -x509 -newkey ec -pkeyopt ec_paramgen_curve:P-256 -nodes \
+  -keyout "${work_dir}/device-ca-key.pem" \
+  -out "${work_dir}/device-ca.pem" \
+  -days 365 -sha256 -config "${work_dir}/ca.cnf"
+
+cat > "${work_dir}/controller.cnf" <<'EOF'
+[req]
+distinguished_name = subject
+prompt = no
+
+[subject]
+CN = localhost
+EOF
+
+cat > "${work_dir}/controller.ext" <<'EOF'
+[v3_server]
+basicConstraints = critical,CA:FALSE
+keyUsage = critical,digitalSignature,keyEncipherment
+extendedKeyUsage = serverAuth
+subjectAltName = DNS:localhost,IP:127.0.0.1
+subjectKeyIdentifier = hash
+authorityKeyIdentifier = keyid,issuer
+EOF
+
+openssl req -new -newkey ec -pkeyopt ec_paramgen_curve:P-256 -nodes \
+  -keyout "${work_dir}/controller-key.pem" \
+  -out "${work_dir}/controller.csr" \
+  -config "${work_dir}/controller.cnf"
+
+openssl x509 -req -in "${work_dir}/controller.csr" \
+  -CA "${work_dir}/device-ca.pem" \
+  -CAkey "${work_dir}/device-ca-key.pem" \
+  -set_serial 1 -days 30 -sha256 \
+  -extfile "${work_dir}/controller.ext" \
+  -extensions v3_server \
+  -out "${work_dir}/controller.pem"
+
+install -d -m 700 "${key_dir}"
+install -m 600 \
+  "${work_dir}/controller-key.pem" \
+  "${work_dir}/device-ca-key.pem" \
+  "${work_dir}/gateway-jwt-key.pem" \
+  "${key_dir}/"
+install -m 644 \
+  "${work_dir}/controller.pem" \
+  "${work_dir}/device-ca.pem" \
+  "${key_dir}/"
+
+echo "Generated Agentdesktop development keys in ${key_dir}"


### PR DESCRIPTION
- fall back to the per-user daemon socket when no system socket exists
- use run for system sockets on macOS
- expose controller JWKS on the admin endpoint for agentgateway
- replace manual key generation with a script

fixes #7 