### PR TITLE
Fix Windows Claude configuration reconciliation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,6 +70,30 @@ jobs:
           make generate-schema
           git diff --exit-code -- schema
 
+  windows:
+    name: Windows agent tests
+    runs-on: windows-2025
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@efa25f7f19611383d5b0ccf2d1c8914531636bf9 # master
+        with:
+          toolchain: "1.97"
+
+      - name: Restore Rust cache
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          shared-key: ci-windows
+          cache-workspace-crates: true
+          save-if: ${{ github.ref == 'refs/heads/main' }}
+
+      - name: Test agent
+        run: cargo test --locked --package agentdesktop-agent
+
   container:
     name: Container
     runs-on: ubuntu-24.04

--- a/crates/agent/src/daemon.rs
+++ b/crates/agent/src/daemon.rs
@@ -251,7 +251,7 @@ where
         args.codex_managed_config.clone(),
         args.open_code_managed_config.clone(),
         args.open_code_plugin.clone(),
-        agentdesktop_executable()?,
+        agentdesktop_client_executable()?,
         socket.clone(),
     );
     if args.once {
@@ -572,8 +572,19 @@ fn bind_named_pipe(path: &std::path::Path, first: bool) -> anyhow::Result<NamedP
     .with_context(|| format!("bind named pipe {}", path.display()))
 }
 
-fn agentdesktop_executable() -> anyhow::Result<PathBuf> {
-    std::env::current_exe().context("locate agentdesktop executable")
+fn agentdesktop_client_executable() -> anyhow::Result<PathBuf> {
+    let executable = std::env::current_exe().context("locate agentdesktop executable")?;
+    Ok(client_executable_for_daemon(&executable))
+}
+
+fn client_executable_for_daemon(executable: &Path) -> PathBuf {
+    if executable.file_name().is_some_and(|name| {
+        name.to_str()
+            .is_some_and(|name| name.eq_ignore_ascii_case("agentdesktop-service.exe"))
+    }) {
+        return executable.with_file_name("agentdesktop.exe");
+    }
+    executable.to_owned()
 }
 
 #[cfg(unix)]
@@ -676,9 +687,25 @@ fn effective_uid() -> u32 {
 
 #[cfg(test)]
 mod tests {
+    use std::path::Path;
+
     use agentdesktop_core::config::parse_daemon;
 
-    use super::{validate_dry_run, validate_one_shot};
+    use super::{client_executable_for_daemon, validate_dry_run, validate_one_shot};
+
+    #[test]
+    fn windows_service_uses_the_sibling_client_executable() {
+        assert_eq!(
+            client_executable_for_daemon(Path::new(
+                "/Program Files/Agent Desktop/agentdesktop-service.exe"
+            )),
+            Path::new("/Program Files/Agent Desktop/agentdesktop.exe")
+        );
+        assert_eq!(
+            client_executable_for_daemon(Path::new("/usr/bin/agentdesktop")),
+            Path::new("/usr/bin/agentdesktop")
+        );
+    }
 
     #[test]
     fn one_shot_accepts_static_settings_and_rejects_runtime_services() {

--- a/crates/agent/src/reconcile/claude_code.rs
+++ b/crates/agent/src/reconcile/claude_code.rs
@@ -10,7 +10,7 @@ use tracing::info;
 
 use crate::secure_fs;
 
-use super::{ReconcileMode, deep_merge, json_merge};
+use super::{CommandSpec, ReconcileMode, deep_merge, json_merge};
 
 const OWNER_MARKER: &[u8] = b"Agentdesktop\n";
 
@@ -18,8 +18,8 @@ pub fn apply(
     path: &Path,
     merge_existing: bool,
     credential_helper: &str,
-    tool_use_hook: Option<&str>,
-    session_new_hook: Option<&str>,
+    tool_use_hook: Option<&CommandSpec>,
+    session_new_hook: Option<&CommandSpec>,
     config: Option<(&ClaudeCodeConfig, Option<&InferenceGatewayConfig>)>,
     mode: ReconcileMode,
 ) -> anyhow::Result<()> {
@@ -153,8 +153,8 @@ fn managed_settings(
     config: &ClaudeCodeConfig,
     gateway: Option<&InferenceGatewayConfig>,
     credential_helper: &str,
-    tool_use_hook: Option<&str>,
-    session_new_hook: Option<&str>,
+    tool_use_hook: Option<&CommandSpec>,
+    session_new_hook: Option<&CommandSpec>,
 ) -> anyhow::Result<Value> {
     let mut settings = serde_json::to_value(&config.settings)
         .context("serialize Claude Code pass-through settings")?;
@@ -185,7 +185,11 @@ fn managed_settings(
     Ok(settings)
 }
 
-fn append_hook(settings: &mut Value, event: &str, hook_command: &str) -> anyhow::Result<()> {
+fn append_hook(
+    settings: &mut Value,
+    event: &str,
+    hook_command: &CommandSpec,
+) -> anyhow::Result<()> {
     let settings = settings
         .as_object_mut()
         .context("Claude Code managed settings must be an object")?;
@@ -199,23 +203,21 @@ fn append_hook(settings: &mut Value, event: &str, hook_command: &str) -> anyhow:
         .or_insert_with(|| Value::Array(Vec::new()))
         .as_array_mut()
         .with_context(|| format!("Claude Code {event} hooks must be an array"))?;
+    let generated_hook = json!({
+        "type": "command",
+        "command": hook_command.program,
+        "args": hook_command.args,
+    });
     let already_present = event_hooks.iter().any(|group| {
         group
             .get("hooks")
             .and_then(Value::as_array)
-            .is_some_and(|hooks| {
-                hooks
-                    .iter()
-                    .any(|hook| hook.get("command").and_then(Value::as_str) == Some(hook_command))
-            })
+            .is_some_and(|hooks| hooks.contains(&generated_hook))
     });
     if !already_present {
         event_hooks.push(json!({
             "matcher": "",
-            "hooks": [{
-                "type": "command",
-                "command": hook_command,
-            }],
+            "hooks": [generated_hook],
         }));
     }
     Ok(())
@@ -289,12 +291,12 @@ fn remove_owner_marker(owner_path: &Path) -> anyhow::Result<()> {
 
 #[cfg(test)]
 mod tests {
-    use std::fs;
+    use std::{fs, path::Path};
 
     use agentdesktop_core::config::parse_daemon;
     use serde_json::{Value, json};
 
-    use super::{ReconcileMode, apply, json_merge, managed_settings};
+    use super::{CommandSpec, ReconcileMode, apply, json_merge, managed_settings};
 
     #[test]
     fn pass_through_settings_are_deep_merged_with_managed_gateway_values() {
@@ -319,12 +321,13 @@ programs:
         .expect("valid daemon configuration");
         let claude = config.programs.claude_code.as_ref().unwrap();
         let gateway = config.inference_gateway.as_ref().unwrap();
+        let hook = CommandSpec::new(Path::new("agentdesktop"), ["hook", "claude-pre-tool-use"]);
 
         let settings = managed_settings(
             claude,
             Some(gateway),
             "agentdesktop credential",
-            Some("agentdesktop hook claude-pre-tool-use"),
+            Some(&hook),
             None,
         )
         .expect("merged settings");
@@ -342,7 +345,11 @@ programs:
         assert_eq!(settings["permissions"], json!({ "defaultMode": "plan" }));
         assert_eq!(
             settings["hooks"]["PreToolUse"][0]["hooks"][0]["command"],
-            "agentdesktop hook claude-pre-tool-use"
+            "agentdesktop"
+        );
+        assert_eq!(
+            settings["hooks"]["PreToolUse"][0]["hooks"][0]["args"],
+            json!(["hook", "claude-pre-tool-use"])
         );
     }
 

--- a/crates/agent/src/reconcile/claude_desktop.rs
+++ b/crates/agent/src/reconcile/claude_desktop.rs
@@ -9,7 +9,9 @@ use tracing::info;
 
 use crate::secure_fs;
 
-use super::{ReconcileMode, deep_merge, json_merge, shell_quote};
+#[cfg(any(not(windows), test))]
+use super::shell_quote;
+use super::{ReconcileMode, deep_merge, json_merge};
 
 const OWNER_MARKER: &[u8] = b"Agentdesktop\n";
 
@@ -50,15 +52,11 @@ pub fn apply(
             .is_some_and(InferenceGatewayAuthentication::uses_credential_helper)
     });
     if uses_credential_helper {
-        let script = format!(
-            "#!/bin/sh\nexec {} --socket {} credential --client-id claude-desktop\n",
-            shell_quote(&credential_binary.to_string_lossy()),
-            shell_quote(&socket.to_string_lossy())
-        );
+        let script = credential_helper_contents(credential_binary, socket)?;
         write_owned(
             helper_path,
             &helper_owner,
-            script.as_bytes(),
+            &script,
             0o755,
             "credential helper",
             mode,
@@ -84,6 +82,50 @@ pub fn apply(
         "managed settings",
         mode,
     )
+}
+
+fn credential_helper_contents(credential_binary: &Path, socket: &Path) -> anyhow::Result<Vec<u8>> {
+    #[cfg(windows)]
+    return windows_credential_helper_contents(
+        &credential_binary.to_string_lossy(),
+        &socket.to_string_lossy(),
+    );
+    #[cfg(not(windows))]
+    return Ok(posix_credential_helper_contents(
+        &credential_binary.to_string_lossy(),
+        &socket.to_string_lossy(),
+    ));
+}
+
+#[cfg(any(not(windows), test))]
+fn posix_credential_helper_contents(credential_binary: &str, socket: &str) -> Vec<u8> {
+    format!(
+        "#!/bin/sh\nexec {} --socket {} credential --client-id claude-desktop\n",
+        shell_quote(credential_binary),
+        shell_quote(socket)
+    )
+    .into_bytes()
+}
+
+#[cfg(any(windows, test))]
+fn windows_credential_helper_contents(
+    credential_binary: &str,
+    socket: &str,
+) -> anyhow::Result<Vec<u8>> {
+    Ok(format!(
+        "@echo off\r\n{} --socket {} credential --client-id claude-desktop\r\n",
+        batch_quote(credential_binary)?,
+        batch_quote(socket)?
+    )
+    .into_bytes())
+}
+
+#[cfg(any(windows, test))]
+fn batch_quote(value: &str) -> anyhow::Result<String> {
+    if value.contains(['"', '\r', '\n']) {
+        anyhow::bail!("Windows helper argument contains an unsupported quote or newline");
+    }
+    Ok(format!("\"{}\"", value.replace('%', "%%")))
 }
 
 fn managed_settings(
@@ -235,9 +277,42 @@ fn remove_owner_marker(path: &Path) -> anyhow::Result<()> {
 mod tests {
     use std::path::Path;
 
+    use super::{
+        batch_quote, managed_settings, posix_credential_helper_contents,
+        windows_credential_helper_contents,
+    };
     use agentdesktop_core::config::parse_daemon;
 
-    use super::managed_settings;
+    #[test]
+    fn generates_platform_specific_credential_helpers() {
+        let binary = r"C:\Program Files\Agent Desktop\agentdesktop.exe";
+        let socket = r"\\.\pipe\agentdesktop";
+
+        let windows = windows_credential_helper_contents(binary, socket).expect("Windows helper");
+        assert_eq!(
+            String::from_utf8(windows).unwrap(),
+            "@echo off\r\n\"C:\\Program Files\\Agent Desktop\\agentdesktop.exe\" --socket \"\\\\.\\pipe\\agentdesktop\" credential --client-id claude-desktop\r\n"
+        );
+
+        let posix = posix_credential_helper_contents(
+            "/opt/Agent Desktop/agentdesktop",
+            "/run/agentdesktop.sock",
+        );
+        assert_eq!(
+            String::from_utf8(posix).unwrap(),
+            "#!/bin/sh\nexec '/opt/Agent Desktop/agentdesktop' --socket '/run/agentdesktop.sock' credential --client-id claude-desktop\n"
+        );
+    }
+
+    #[test]
+    fn escapes_batch_expansion_and_rejects_unrepresentable_arguments() {
+        assert_eq!(
+            batch_quote(r"C:\Agent%TEMP%\agentdesktop.exe").unwrap(),
+            r#""C:\Agent%%TEMP%%\agentdesktop.exe""#
+        );
+        assert!(batch_quote("bad\"path").is_err());
+        assert!(batch_quote("bad\npath").is_err());
+    }
 
     #[test]
     fn gateway_settings_override_pass_through_values() {

--- a/crates/agent/src/reconcile/mod.rs
+++ b/crates/agent/src/reconcile/mod.rs
@@ -11,8 +11,25 @@ use std::{
 };
 
 use agentdesktop_core::config::{DaemonConfig, InferenceGatewayConfig};
+#[cfg(any(windows, test))]
+use base64::{Engine as _, prelude::BASE64_STANDARD};
 use serde_json::Value;
 use similar::TextDiff;
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct CommandSpec {
+    program: String,
+    args: Vec<String>,
+}
+
+impl CommandSpec {
+    fn new(program: &Path, args: impl IntoIterator<Item = impl Into<String>>) -> Self {
+        Self {
+            program: program.to_string_lossy().into_owned(),
+            args: args.into_iter().map(Into::into).collect(),
+        }
+    }
+}
 
 #[derive(Clone, Copy)]
 enum ReconcileMode<'a> {
@@ -242,8 +259,8 @@ impl Reconciler {
             &self.claude_code_settings_path,
             self.merge_user_settings,
             &self.claude_credential_helper_command(),
-            tool_use_hook.as_deref(),
-            session_new_hook.as_deref(),
+            tool_use_hook.as_ref(),
+            session_new_hook.as_ref(),
             claude_code,
             mode,
         )?;
@@ -295,36 +312,85 @@ impl Reconciler {
     }
 
     fn claude_credential_helper_command(&self) -> String {
-        format!(
-            "{} --socket {} credential --client-id claude-code",
-            shell_quote(&self.credential_helper.to_string_lossy()),
-            shell_quote(&self.socket.to_string_lossy())
-        )
+        render_command(&CommandSpec::new(
+            &self.credential_helper,
+            [
+                "--socket".to_owned(),
+                self.socket.to_string_lossy().into_owned(),
+                "credential".to_owned(),
+                "--client-id".to_owned(),
+                "claude-code".to_owned(),
+            ],
+        ))
     }
 
-    fn claude_hook_command(&self, include_input: bool) -> String {
-        let mut command = format!(
-            "{} --socket {} hook claude-pre-tool-use",
-            shell_quote(&self.credential_helper.to_string_lossy()),
-            shell_quote(&self.socket.to_string_lossy())
-        );
+    fn claude_hook_command(&self, include_input: bool) -> CommandSpec {
+        let mut args = vec![
+            "--socket".to_owned(),
+            self.socket.to_string_lossy().into_owned(),
+            "hook".to_owned(),
+            "claude-pre-tool-use".to_owned(),
+        ];
         if include_input {
-            command.push_str(" --include-input");
+            args.push("--include-input".to_owned());
         }
-        command
+        CommandSpec::new(&self.credential_helper, args)
     }
 
-    fn claude_session_hook_command(&self) -> String {
-        format!(
-            "{} --socket {} hook claude-session-start",
-            shell_quote(&self.credential_helper.to_string_lossy()),
-            shell_quote(&self.socket.to_string_lossy())
+    fn claude_session_hook_command(&self) -> CommandSpec {
+        CommandSpec::new(
+            &self.credential_helper,
+            [
+                "--socket".to_owned(),
+                self.socket.to_string_lossy().into_owned(),
+                "hook".to_owned(),
+                "claude-session-start".to_owned(),
+            ],
         )
     }
 }
 
+#[cfg(any(not(windows), test))]
 fn shell_quote(value: &str) -> String {
     format!("'{}'", value.replace('\'', "'\\''"))
+}
+
+#[cfg(any(windows, test))]
+fn powershell_quote(value: &str) -> String {
+    format!("'{}'", value.replace('\'', "''"))
+}
+
+fn render_command(command: &CommandSpec) -> String {
+    #[cfg(windows)]
+    return render_windows_command(command);
+    #[cfg(not(windows))]
+    return render_posix_command(command);
+}
+
+#[cfg(any(not(windows), test))]
+fn render_posix_command(command: &CommandSpec) -> String {
+    std::iter::once(command.program.as_str())
+        .chain(command.args.iter().map(String::as_str))
+        .map(shell_quote)
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+#[cfg(any(windows, test))]
+fn render_windows_command(command: &CommandSpec) -> String {
+    let script = std::iter::once(command.program.as_str())
+        .chain(command.args.iter().map(String::as_str))
+        .map(powershell_quote)
+        .collect::<Vec<_>>()
+        .join(" ");
+    let encoded = format!("& {script}")
+        .encode_utf16()
+        .flat_map(u16::to_le_bytes)
+        .collect::<Vec<_>>();
+    format!(
+        "powershell.exe -NoLogo -NoProfile -NonInteractive -EncodedCommand {}",
+        BASE64_STANDARD.encode(encoded)
+    )
 }
 
 fn deep_merge(base: &mut Value, overlay: Value) {
@@ -364,7 +430,13 @@ pub fn default_claude_desktop_managed_settings_path() -> PathBuf {
 
 /// Returns the path of Agentdesktop's Claude Desktop credential helper.
 pub fn default_claude_desktop_credential_helper_path() -> PathBuf {
-    PathBuf::from("/etc/claude-desktop/agentdesktop-credential-helper")
+    #[cfg(windows)]
+    return std::env::var_os("ProgramData")
+        .map(PathBuf::from)
+        .unwrap_or_else(|| PathBuf::from(r"C:\ProgramData"))
+        .join("AgentDesktop/claude-desktop-credential-helper.cmd");
+    #[cfg(not(windows))]
+    return PathBuf::from("/etc/claude-desktop/agentdesktop-credential-helper");
 }
 
 /// Returns the system-wide OpenCode managed configuration path.
@@ -392,11 +464,116 @@ pub fn default_claude_code_managed_settings_dir() -> PathBuf {
 
 #[cfg(test)]
 mod tests {
-    use std::{fs, path::Path};
+    use std::{fs, path::Path, path::PathBuf};
 
     use agentdesktop_core::config::parse_daemon;
+    use base64::{Engine as _, prelude::BASE64_STANDARD};
 
-    use super::{DryRunReport, Reconciler};
+    use super::{
+        CommandSpec, DryRunReport, Reconciler, default_claude_desktop_credential_helper_path,
+        render_posix_command, render_windows_command,
+    };
+
+    #[test]
+    fn renders_posix_commands_with_each_argument_quoted() {
+        let command = CommandSpec::new(
+            Path::new("/Applications/Agent Desktop/agentdesktop"),
+            ["--socket", "/tmp/agent's socket", "credential"],
+        );
+
+        assert_eq!(
+            render_posix_command(&command),
+            "'/Applications/Agent Desktop/agentdesktop' '--socket' '/tmp/agent'\\''s socket' 'credential'"
+        );
+    }
+
+    #[test]
+    fn renders_windows_commands_as_shell_neutral_encoded_powershell() {
+        let command = CommandSpec::new(
+            Path::new(r"C:\Program Files\Agent Desktop\agentdesktop.exe"),
+            [
+                "--socket",
+                r"\\.\pipe\agentdesktop",
+                "credential",
+                "--client-id",
+                "claude-code",
+            ],
+        );
+
+        let rendered = render_windows_command(&command);
+        let encoded = rendered
+            .strip_prefix("powershell.exe -NoLogo -NoProfile -NonInteractive -EncodedCommand ")
+            .expect("explicit PowerShell launcher");
+        let bytes = BASE64_STANDARD.decode(encoded).expect("valid base64");
+        let utf16 = bytes
+            .chunks_exact(2)
+            .map(|bytes| u16::from_le_bytes([bytes[0], bytes[1]]))
+            .collect::<Vec<_>>();
+        let script = String::from_utf16(&utf16).expect("valid UTF-16LE");
+
+        assert_eq!(
+            script,
+            r"& 'C:\Program Files\Agent Desktop\agentdesktop.exe' '--socket' '\\.\pipe\agentdesktop' 'credential' '--client-id' 'claude-code'"
+        );
+    }
+
+    #[test]
+    fn claude_hooks_keep_the_executable_and_arguments_separate() {
+        let reconciler = Reconciler::new(
+            false,
+            PathBuf::new(),
+            PathBuf::new(),
+            PathBuf::new(),
+            PathBuf::new(),
+            PathBuf::new(),
+            PathBuf::new(),
+            PathBuf::from(r"C:\Program Files\Agent Desktop\agentdesktop.exe"),
+            PathBuf::from(r"\\.\pipe\agentdesktop"),
+        );
+
+        let tool = reconciler.claude_hook_command(true);
+        assert_eq!(
+            tool.program,
+            r"C:\Program Files\Agent Desktop\agentdesktop.exe"
+        );
+        assert_eq!(
+            tool.args,
+            [
+                "--socket",
+                r"\\.\pipe\agentdesktop",
+                "hook",
+                "claude-pre-tool-use",
+                "--include-input",
+            ]
+        );
+        assert_eq!(
+            reconciler.claude_session_hook_command().args,
+            [
+                "--socket",
+                r"\\.\pipe\agentdesktop",
+                "hook",
+                "claude-session-start",
+            ]
+        );
+    }
+
+    #[test]
+    fn claude_desktop_helper_default_matches_the_native_script_type() {
+        #[cfg(windows)]
+        {
+            assert_eq!(
+                default_claude_desktop_credential_helper_path().extension(),
+                Some(std::ffi::OsStr::new("cmd"))
+            );
+        }
+        #[cfg(not(windows))]
+        {
+            assert_eq!(
+                default_claude_desktop_credential_helper_path(),
+                PathBuf::from("/etc/claude-desktop/agentdesktop-credential-helper")
+            );
+        }
+    }
 
     #[test]
     fn dry_run_report_shows_changes_and_hides_unchanged_files() {


### PR DESCRIPTION
Generate a Windows-safe Claude Code API key helper command, use exec-form hooks on every platform, and create a native batch helper for Claude Desktop. Resolve the client binary correctly when running as a Windows service and add platform-focused tests and Windows CI coverage.

https://github.com/agentdesktop-dev/agentdesktop/issues/33

cc @peterj @howardjohn @yuval-k 