### PR TITLE
Add Grok Build managed gateway configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ stage.
 | Cursor | Yes | — | MCP and skills | — |
 | OpenCode | Yes | Yes | MCP | — |
 | VS Code | Yes | — | MCP and skills | — |
-| Grok Build | Yes | — | MCP and skills | — |
+| Grok Build | Yes | Yes | MCP and skills | — |
 
 > **Don't see your tool?** We're actively expanding this list and would love
 > your help. [Open an integration request](https://github.com/agentdesktop-dev/agentdesktop/issues/new)

--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ stage.
 | Cursor | Yes | — | MCP and skills | — |
 | OpenCode | Yes | Yes | MCP | — |
 | VS Code | Yes | — | MCP and skills | — |
-| Grok Build | Yes | Yes | MCP and skills | — |
+| Grok Build | Yes | Linux/macOS system mode | MCP and skills | — |
 
 > **Don't see your tool?** We're actively expanding this list and would love
 > your help. [Open an integration request](https://github.com/agentdesktop-dev/agentdesktop/issues/new)

--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ stage.
 | Cursor | Yes | — | MCP and skills | — |
 | OpenCode | Yes | Yes | MCP | — |
 | VS Code | Yes | — | MCP and skills | — |
-| Grok Build | Yes | Linux/macOS system mode | MCP and skills | — |
+| Grok Build | Yes | System mode | MCP and skills | — |
 
 > **Don't see your tool?** We're actively expanding this list and would love
 > your help. [Open an integration request](https://github.com/agentdesktop-dev/agentdesktop/issues/new)

--- a/crates/agent/src/daemon.rs
+++ b/crates/agent/src/daemon.rs
@@ -88,6 +88,10 @@ pub struct DaemonArgs {
     /// Path used for Agentdesktop's OpenCode credential plugin.
     #[arg(long)]
     open_code_plugin: Option<PathBuf>,
+
+    /// Path to Grok Build's organization-managed TOML configuration.
+    #[arg(long)]
+    grok_managed_config: Option<PathBuf>,
 }
 
 struct ResolvedDaemonArgs {
@@ -102,6 +106,7 @@ struct ResolvedDaemonArgs {
     codex_managed_config: PathBuf,
     open_code_managed_config: PathBuf,
     open_code_plugin: PathBuf,
+    grok_managed_config: PathBuf,
     once: bool,
     dry_run: bool,
 }
@@ -134,6 +139,9 @@ impl DaemonArgs {
                 open_code_plugin: self
                     .open_code_plugin
                     .unwrap_or_else(reconcile::default_open_code_plugin_path),
+                grok_managed_config: self
+                    .grok_managed_config
+                    .unwrap_or_else(reconcile::default_grok_managed_config_path),
                 once: self.once || self.dry_run,
                 dry_run: self.dry_run,
             });
@@ -181,6 +189,13 @@ impl DaemonArgs {
             open_code_plugin: self
                 .open_code_plugin
                 .unwrap_or_else(|| config_home.join("opencode/plugins/agentdesktop.js")),
+            grok_managed_config: self.grok_managed_config.unwrap_or_else(|| {
+                std::env::var_os("GROK_HOME")
+                    .filter(|value| !value.is_empty())
+                    .map(PathBuf::from)
+                    .unwrap_or_else(|| home.join(".grok"))
+                    .join("managed_config.toml")
+            }),
             once: self.once || self.dry_run,
             dry_run: self.dry_run,
         })
@@ -249,6 +264,7 @@ where
         args.codex_managed_config.clone(),
         args.open_code_managed_config.clone(),
         args.open_code_plugin.clone(),
+        args.grok_managed_config.clone(),
         agentdesktop_client_executable()?,
         socket.clone(),
     );
@@ -489,6 +505,11 @@ fn validate_one_shot(config: &agentdesktop_core::config::DaemonConfig) -> anyhow
             config
                 .programs
                 .open_code
+                .as_ref()
+                .is_some_and(|program| program.use_llm_gateway),
+            config
+                .programs
+                .grok
                 .as_ref()
                 .is_some_and(|program| program.use_llm_gateway),
         ]

--- a/crates/agent/src/provider/README.md
+++ b/crates/agent/src/provider/README.md
@@ -10,9 +10,9 @@ Features currently implemented by Agentdesktop.
 | Local model discovery | — | — | — | — | — | ✅ | — | — |
 | MCP server discovery | ✅ | ✅ | ✅ | ◯ | ✅ | — | ✅ | ✅ |
 | Skill discovery | ✅ | ◯ | ✅ | ◯ | ✅ | — | ✅ | ✅ |
-| Managed configuration | ✅ | ✅ | ✅ | ✅ | ◯ | ◯ | ◯ | ◯ |
-| LLM gateway routing | ✅ | ✅ | ✅ | ✅ | ◯ | — | ◯ | ◯ |
-| Gateway credentials | ✅ | ✅ | ✅ | ✅ | ◯ | — | ◯ | ◯ |
+| Managed configuration | ✅ | ✅ | ✅ | ✅ | ◯ | ◯ | ◯ | ✅ |
+| LLM gateway routing | ✅ | ✅ | ✅ | ✅ | ◯ | — | ◯ | ✅ |
+| Gateway credentials | ✅ | ✅ | ✅ | ✅ | ◯ | — | ◯ | ✅ |
 | Sandbox configuration | ✅ | ◯ | ✅ | ◯ | ◯ | — | ◯ | ◯ |
 | Tool-use telemetry | ✅ | ◯ | ◯ | ◯ | ◯ | — | ◯ | ◯ |
 | Session-start telemetry | ✅ | ◯ | ◯ | ◯ | ◯ | — | ◯ | ◯ |

--- a/crates/agent/src/provider/README.md
+++ b/crates/agent/src/provider/README.md
@@ -2,6 +2,11 @@
 
 Features currently implemented by Agentdesktop.
 
+Grok Build managed configuration requires system mode on Linux or macOS and uses
+`/etc/grok/managed_config.toml`. `--user` rejects `programs.grok` because Grok's
+own configuration sync can delete or replace the user-level managed file.
+Grok does not load system-managed configuration on Windows.
+
 ✅ Implemented · ◯ Not implemented · — Not applicable
 
 | Feature | [Claude Code](claude_code/) | [Claude Desktop](claude_desktop/) | [Codex](codex/) | [OpenCode](opencode/) | [VS Code](vscode/) | [Ollama](ollama/) | [Cursor](cursor/) | [Grok Build](grok/) |

--- a/crates/agent/src/provider/README.md
+++ b/crates/agent/src/provider/README.md
@@ -2,10 +2,11 @@
 
 Features currently implemented by Agentdesktop.
 
-Grok Build managed configuration requires system mode on Linux or macOS and uses
-`/etc/grok/managed_config.toml`. `--user` rejects `programs.grok` because Grok's
-own configuration sync can delete or replace the user-level managed file.
-Grok does not load system-managed configuration on Windows.
+Grok Build managed configuration requires system mode. Linux and macOS use
+`/etc/grok/managed_config.toml`; Windows uses the system drive's
+`\etc\grok\managed_config.toml`. `--user` rejects `programs.grok` because
+Grok's own configuration sync can delete or replace the user-level managed
+file.
 
 ✅ Implemented · ◯ Not implemented · — Not applicable
 

--- a/crates/agent/src/provider/grok/mod.rs
+++ b/crates/agent/src/provider/grok/mod.rs
@@ -1,10 +1,26 @@
+use std::path::PathBuf;
+
+use agentdesktop_core::config::DaemonConfig;
 use agentdesktop_core::model::Discovery;
 
-use super::Provider;
+use super::{Provider, ReconcileContext};
+use crate::reconcile::ReconcilePlan;
 
-mod discovery;
+pub(super) mod discovery;
+mod reconcile;
 
-pub struct Grok;
+#[derive(Clone)]
+pub struct Grok {
+    pub managed_config_path: PathBuf,
+}
+
+impl Default for Grok {
+    fn default() -> Self {
+        Self {
+            managed_config_path: default_grok_managed_config_path(),
+        }
+    }
+}
 
 impl Grok {
     pub const ID: &'static str = "grok";
@@ -19,4 +35,28 @@ impl Provider for Grok {
             model_runtimes: Vec::new(),
         }
     }
+
+    fn plan(&self, ctx: &ReconcileContext, config: &DaemonConfig) -> anyhow::Result<ReconcilePlan> {
+        let configured = config.programs.grok.as_ref().map(|provider| {
+            let gateway = config
+                .llm_gateway
+                .as_ref()
+                .filter(|_| provider.use_llm_gateway);
+            (provider, gateway)
+        });
+        let plan = ReconcilePlan::default();
+        reconcile::plan(
+            &self.managed_config_path,
+            &ctx.credential_helper,
+            &ctx.socket,
+            configured,
+            &plan,
+        )?;
+        Ok(plan)
+    }
+}
+
+/// Returns the system-wide Grok Build managed configuration path.
+pub fn default_grok_managed_config_path() -> PathBuf {
+    PathBuf::from("/etc/grok/managed_config.toml")
 }

--- a/crates/agent/src/provider/grok/mod.rs
+++ b/crates/agent/src/provider/grok/mod.rs
@@ -37,14 +37,9 @@ impl Provider for Grok {
     }
 
     fn plan(&self, ctx: &ReconcileContext, config: &DaemonConfig) -> anyhow::Result<ReconcilePlan> {
-        if cfg!(windows) && config.programs.grok.is_some() {
-            anyhow::bail!(
-                "Grok Build does not load system-managed configuration on Windows; remove programs.grok (managed configuration requires Linux or macOS)"
-            );
-        }
         if ctx.merge_user_settings && config.programs.grok.is_some() {
             anyhow::bail!(
-                "Grok Build can delete or replace its user-level managed_config.toml during startup; remove programs.grok or run agentdesktop without --user as root so it can manage /etc/grok/managed_config.toml"
+                "Grok Build can delete or replace its user-level managed_config.toml during startup; remove programs.grok or run agentdesktop in system mode so it can manage Grok's system managed_config.toml"
             );
         }
         let configured = config.programs.grok.as_ref().map(|provider| {
@@ -68,5 +63,50 @@ impl Provider for Grok {
 
 /// Returns the system-wide Grok Build managed configuration path.
 pub fn default_grok_managed_config_path() -> PathBuf {
+    #[cfg(windows)]
+    return windows_system_managed_config_path(
+        std::env::var_os("SystemDrive").or_else(|| std::env::var_os("SYSTEMDRIVE")),
+    );
+
+    #[cfg(not(windows))]
     PathBuf::from("/etc/grok/managed_config.toml")
+}
+
+#[cfg(any(windows, test))]
+fn windows_system_managed_config_path(system_drive: Option<std::ffi::OsString>) -> PathBuf {
+    let drive = system_drive
+        .filter(|value| !value.is_empty())
+        .unwrap_or_else(|| "C:".into());
+    let mut drive = drive
+        .to_string_lossy()
+        .trim_end_matches(['\\', '/'])
+        .to_owned();
+    if drive.len() == 1 && drive.as_bytes()[0].is_ascii_alphabetic() {
+        drive.push(':');
+    }
+    if drive.is_empty() || !drive.ends_with(':') {
+        drive = "C:".to_owned();
+    }
+    PathBuf::from(format!(r"{drive}\etc\grok\managed_config.toml"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::windows_system_managed_config_path;
+
+    #[test]
+    fn windows_system_managed_config_path_uses_system_drive_root() {
+        assert_eq!(
+            windows_system_managed_config_path(Some("D:".into())),
+            std::path::PathBuf::from(r"D:\etc\grok\managed_config.toml")
+        );
+        assert_eq!(
+            windows_system_managed_config_path(Some(r"E:\".into())),
+            std::path::PathBuf::from(r"E:\etc\grok\managed_config.toml")
+        );
+        assert_eq!(
+            windows_system_managed_config_path(None),
+            std::path::PathBuf::from(r"C:\etc\grok\managed_config.toml")
+        );
+    }
 }

--- a/crates/agent/src/provider/grok/mod.rs
+++ b/crates/agent/src/provider/grok/mod.rs
@@ -44,7 +44,7 @@ impl Provider for Grok {
         }
         if ctx.merge_user_settings && config.programs.grok.is_some() {
             anyhow::bail!(
-                "Grok Build can delete or replace its user-level managed_config.toml during startup; remove programs.grok or run Agentdesktop without --user as root so it can manage /etc/grok/managed_config.toml"
+                "Grok Build can delete or replace its user-level managed_config.toml during startup; remove programs.grok or run agentdesktop without --user as root so it can manage /etc/grok/managed_config.toml"
             );
         }
         let configured = config.programs.grok.as_ref().map(|provider| {

--- a/crates/agent/src/provider/grok/mod.rs
+++ b/crates/agent/src/provider/grok/mod.rs
@@ -37,6 +37,16 @@ impl Provider for Grok {
     }
 
     fn plan(&self, ctx: &ReconcileContext, config: &DaemonConfig) -> anyhow::Result<ReconcilePlan> {
+        if cfg!(windows) && config.programs.grok.is_some() {
+            anyhow::bail!(
+                "Grok Build does not load system-managed configuration on Windows; remove programs.grok (managed configuration requires Linux or macOS)"
+            );
+        }
+        if ctx.merge_user_settings && config.programs.grok.is_some() {
+            anyhow::bail!(
+                "Grok Build can delete or replace its user-level managed_config.toml during startup; remove programs.grok or run Agentdesktop without --user as root so it can manage /etc/grok/managed_config.toml"
+            );
+        }
         let configured = config.programs.grok.as_ref().map(|provider| {
             let gateway = config
                 .llm_gateway

--- a/crates/agent/src/provider/grok/reconcile.rs
+++ b/crates/agent/src/provider/grok/reconcile.rs
@@ -173,7 +173,7 @@ fn catalog_entries(config: &GrokConfig, default_model: &str) -> Vec<(String, Val
             default_model.to_owned(),
             json!({
                 "model": default_model,
-                "name": "Agentdesktop",
+                "name": "agentdesktop",
             }),
         )];
     }
@@ -204,7 +204,7 @@ fn remove(path: &Path, plan: &ReconcilePlan) -> anyhow::Result<()> {
                 program = Grok::ID,
                 action = "unchanged",
                 path = %path.display(),
-                "preserving managed configuration not owned by Agentdesktop"
+                "preserving managed configuration not owned by agentdesktop"
             );
             plan.record(Grok::DISPLAY_NAME, "configuration", "unchanged", path);
             Ok(())
@@ -322,7 +322,7 @@ programs:
 
         assert_eq!(settings["models"]["default"], "grok-4.6");
         assert_eq!(settings["model"]["grok-4.6"]["model"], "grok-4.6");
-        assert_eq!(settings["model"]["grok-4.6"]["name"], "Agentdesktop");
+        assert_eq!(settings["model"]["grok-4.6"]["name"], "agentdesktop");
         assert_eq!(
             settings["model"]["grok-4.6"]["base_url"],
             "http://127.0.0.1:4000/v1"

--- a/crates/agent/src/provider/grok/reconcile.rs
+++ b/crates/agent/src/provider/grok/reconcile.rs
@@ -106,35 +106,31 @@ fn managed_config(
         .filter(|model| !model.trim().is_empty())
         .context("Grok gateway configuration has no model")?;
     let catalog = catalog_entries(config, default_model);
+    let uses_credential_helper = gateway
+        .authentication
+        .as_ref()
+        .is_some_and(LlmGatewayAuthentication::uses_credential_helper);
     let mut models = Map::new();
-    for (id, value) in catalog {
+    for (id, value) in &catalog {
         let mut entry = match value {
-            Value::Object(_) => value,
+            Value::Object(_) => value.clone(),
             _ => json!({}),
         };
         if entry.get("model").and_then(Value::as_str).is_none() {
             entry["model"] = json!(id);
         }
         entry["base_url"] = json!(responses_base_url(gateway));
-        if gateway
-            .authentication
-            .as_ref()
-            .is_some_and(LlmGatewayAuthentication::uses_credential_helper)
-        {
+        if uses_credential_helper {
             entry["auth_provider"] = json!(PROVIDER_NAME);
         }
-        models.insert(id, entry);
+        models.insert(id.clone(), entry);
     }
 
     let mut generated = json!({
         "models": { "default": default_model },
         "model": models,
     });
-    if gateway
-        .authentication
-        .as_ref()
-        .is_some_and(LlmGatewayAuthentication::uses_credential_helper)
-    {
+    if uses_credential_helper {
         let timeout_secs = if matches!(
             gateway.authentication,
             Some(LlmGatewayAuthentication::Oidc { .. })
@@ -158,6 +154,16 @@ fn managed_config(
         });
     }
     deep_merge(&mut settings, generated);
+    if uses_credential_helper {
+        // Grok resolves static credentials before auth_provider. Clear both
+        // sources after merging so pass-through values cannot shadow our helper.
+        for (id, _) in catalog {
+            if let Some(entry) = settings["model"][&id].as_object_mut() {
+                entry.remove("api_key");
+                entry.remove("env_key");
+            }
+        }
+    }
     Ok(settings)
 }
 
@@ -322,6 +328,116 @@ programs:
             "http://127.0.0.1:4000/v1"
         );
         assert!(settings.get("auth_provider").is_none());
+    }
+
+    #[test]
+    fn gateway_credentials_override_static_credentials_from_both_config_maps() {
+        let config = parse_daemon(
+            r#"
+llmGateway:
+  url: https://gateway.example.com
+  authentication:
+    type: controllerJwt
+    audience: agentgateway
+    allowedClientIds: [grok]
+programs:
+  grok:
+    model: grok-4.6
+    models:
+      grok-4.6:
+        api_key: catalog-key
+        env_key: CATALOG_KEY
+      secondary:
+        model: another-model
+    managedConfig:
+      model:
+        grok-4.6:
+          api_key: pass-through-key
+          env_key: PASS_THROUGH_KEY
+          context_window: 128000
+        secondary:
+          api_key: secondary-key
+          env_key: [SECONDARY_KEY]
+        unmanaged:
+          api_key: unmanaged-key
+"#,
+        )
+        .unwrap();
+        let grok = config.programs.grok.as_ref().unwrap();
+        let settings = managed_config(
+            grok,
+            config.llm_gateway.as_ref(),
+            Path::new("/bin/agentdesktop"),
+            Path::new("/tmp/agentdesktop.sock"),
+        )
+        .unwrap();
+
+        for id in ["grok-4.6", "secondary"] {
+            let model = &settings["model"][id];
+            assert_eq!(model["auth_provider"], "agentdesktop");
+            assert!(
+                model.get("api_key").is_none(),
+                "static key shadows helper for {id}"
+            );
+            assert!(
+                model.get("env_key").is_none(),
+                "environment key shadows helper for {id}"
+            );
+        }
+        assert_eq!(settings["model"]["grok-4.6"]["context_window"], 128000);
+        assert_eq!(settings["model"]["unmanaged"]["api_key"], "unmanaged-key");
+
+        // The synthesized default entry must also clear pass-through credentials.
+        let mut grok = grok.clone();
+        grok.models.clear();
+        let settings = managed_config(
+            &grok,
+            config.llm_gateway.as_ref(),
+            Path::new("/bin/agentdesktop"),
+            Path::new("/tmp/agentdesktop.sock"),
+        )
+        .unwrap();
+        assert!(settings["model"]["grok-4.6"].get("api_key").is_none());
+        assert!(settings["model"]["grok-4.6"].get("env_key").is_none());
+    }
+
+    #[test]
+    fn static_credentials_are_preserved_without_a_gateway_credential_helper() {
+        let config = parse_daemon(
+            r#"
+llmGateway:
+  url: https://gateway.example.com
+programs:
+  grok:
+    model: custom
+    models:
+      custom:
+        api_key: catalog-key
+        env_key: CATALOG_KEY
+    managedConfig:
+      model:
+        custom:
+          api_key: pass-through-key
+          env_key: PASS_THROUGH_KEY
+"#,
+        )
+        .unwrap();
+        let grok = config.programs.grok.as_ref().unwrap();
+        for (gateway, expected_key, expected_env) in [
+            (config.llm_gateway.as_ref(), "catalog-key", "CATALOG_KEY"),
+            (None, "pass-through-key", "PASS_THROUGH_KEY"),
+        ] {
+            let settings = managed_config(
+                grok,
+                gateway,
+                Path::new("/bin/agentdesktop"),
+                Path::new("/tmp/agentdesktop.sock"),
+            )
+            .unwrap();
+            assert_eq!(settings["model"]["custom"]["api_key"], expected_key);
+            assert_eq!(settings["model"]["custom"]["env_key"], expected_env);
+            assert!(settings["model"]["custom"].get("auth_provider").is_none());
+        }
     }
 
     #[test]

--- a/crates/agent/src/provider/grok/reconcile.rs
+++ b/crates/agent/src/provider/grok/reconcile.rs
@@ -10,7 +10,7 @@ use tracing::debug;
 use crate::provider::shared::{deep_merge, responses_base_url};
 use crate::reconcile::ReconcilePlan;
 
-const MANAGED_HEADER: &str = "# Managed by Agentdesktop. Manual changes will be replaced.\n";
+const MANAGED_HEADER: &str = "# Managed by agentdesktop. Manual changes will be replaced.\n";
 const PROVIDER_NAME: &str = "agentdesktop";
 
 pub(super) fn plan(

--- a/crates/agent/src/provider/grok/reconcile.rs
+++ b/crates/agent/src/provider/grok/reconcile.rs
@@ -1,0 +1,357 @@
+use super::Grok;
+
+use std::path::Path;
+
+use agentdesktop_core::config::{GrokConfig, LlmGatewayAuthentication, LlmGatewayConfig};
+use anyhow::Context;
+use serde_json::{Map, Value, json};
+use tracing::debug;
+
+use crate::provider::shared::{deep_merge, responses_base_url};
+use crate::reconcile::ReconcilePlan;
+
+const MANAGED_HEADER: &str = "# Managed by Agentdesktop. Manual changes will be replaced.\n";
+const PROVIDER_NAME: &str = "agentdesktop";
+
+pub(super) fn plan(
+    path: &Path,
+    credential_helper: &Path,
+    socket: &Path,
+    config: Option<(&GrokConfig, Option<&LlmGatewayConfig>)>,
+    plan: &ReconcilePlan,
+) -> anyhow::Result<()> {
+    let Some((config, gateway)) = config else {
+        return remove(path, plan);
+    };
+
+    let settings = managed_config(config, gateway, credential_helper, socket)?;
+    let mut contents = MANAGED_HEADER.as_bytes().to_vec();
+    contents.extend_from_slice(
+        toml::to_string_pretty(&settings)
+            .context("serialize Grok managed configuration as TOML")?
+            .as_bytes(),
+    );
+    if !contents.ends_with(b"\n") {
+        contents.push(b'\n');
+    }
+
+    let existing = match plan.read(path) {
+        Ok(existing) => Some(existing),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => None,
+        Err(error) => {
+            return Err(error).with_context(|| {
+                format!("read Grok managed configuration from {}", path.display())
+            });
+        }
+    };
+    let action = match existing.as_deref() {
+        Some(existing) if existing == contents => {
+            debug!(
+                program = Grok::ID,
+                action = "unchanged",
+                path = %path.display(),
+                "managed configuration already current"
+            );
+            plan.record(Grok::DISPLAY_NAME, "configuration", "unchanged", path);
+            return Ok(());
+        }
+        Some(existing) if existing.starts_with(MANAGED_HEADER.as_bytes()) => "update",
+        Some(existing) => {
+            plan.record_diff(
+                Grok::DISPLAY_NAME,
+                "configuration",
+                "conflict",
+                path,
+                Some(existing),
+                Some(&contents),
+            );
+            return Ok(());
+        }
+        None => "create",
+    };
+
+    plan.write_file(path, &contents, 0o644)?;
+    debug!(
+        program = Grok::ID,
+        action,
+        path = %path.display(),
+        "planned managed configuration"
+    );
+    plan.record_diff(
+        Grok::DISPLAY_NAME,
+        "configuration",
+        action,
+        path,
+        existing.as_deref(),
+        Some(&contents),
+    );
+    Ok(())
+}
+
+fn managed_config(
+    config: &GrokConfig,
+    gateway: Option<&LlmGatewayConfig>,
+    credential_helper: &Path,
+    socket: &Path,
+) -> anyhow::Result<Value> {
+    let mut settings = serde_json::to_value(&config.managed_config)
+        .context("serialize Grok pass-through managed configuration")?;
+    let Some(gateway) = gateway else {
+        return Ok(settings);
+    };
+
+    let default_model = config
+        .model
+        .as_deref()
+        .filter(|model| !model.trim().is_empty())
+        .context("Grok gateway configuration has no model")?;
+    let catalog = catalog_entries(config, default_model);
+    let mut models = Map::new();
+    for (id, value) in catalog {
+        let mut entry = match value {
+            Value::Object(_) => value,
+            _ => json!({}),
+        };
+        if entry.get("model").and_then(Value::as_str).is_none() {
+            entry["model"] = json!(id);
+        }
+        entry["base_url"] = json!(responses_base_url(gateway));
+        if gateway
+            .authentication
+            .as_ref()
+            .is_some_and(LlmGatewayAuthentication::uses_credential_helper)
+        {
+            entry["auth_provider"] = json!(PROVIDER_NAME);
+        }
+        models.insert(id, entry);
+    }
+
+    let mut generated = json!({
+        "models": { "default": default_model },
+        "model": models,
+    });
+    if gateway
+        .authentication
+        .as_ref()
+        .is_some_and(LlmGatewayAuthentication::uses_credential_helper)
+    {
+        let timeout_secs = if matches!(
+            gateway.authentication,
+            Some(LlmGatewayAuthentication::Oidc { .. })
+        ) {
+            600
+        } else {
+            5
+        };
+        generated["auth_provider"] = json!({
+            (PROVIDER_NAME): {
+                "command": credential_helper.to_string_lossy(),
+                "args": [
+                    "--socket",
+                    socket.to_string_lossy(),
+                    "credential",
+                    "--client-id",
+                    Grok::ID,
+                ],
+                "timeout_secs": timeout_secs,
+            },
+        });
+    }
+    deep_merge(&mut settings, generated);
+    Ok(settings)
+}
+
+fn catalog_entries(config: &GrokConfig, default_model: &str) -> Vec<(String, Value)> {
+    if config.models.is_empty() {
+        return vec![(
+            default_model.to_owned(),
+            json!({
+                "model": default_model,
+                "name": "Agentdesktop",
+            }),
+        )];
+    }
+    config
+        .models
+        .iter()
+        .map(|(id, value)| (id.clone(), value.clone()))
+        .collect()
+}
+
+fn remove(path: &Path, plan: &ReconcilePlan) -> anyhow::Result<()> {
+    match plan.read(path) {
+        Ok(contents) if contents.starts_with(MANAGED_HEADER.as_bytes()) => {
+            plan.remove_file(path).with_context(|| {
+                format!("remove Grok managed configuration at {}", path.display())
+            })?;
+            debug!(
+                program = Grok::ID,
+                action = "remove",
+                path = %path.display(),
+                "planned managed configuration"
+            );
+            plan.record(Grok::DISPLAY_NAME, "configuration", "remove", path);
+            Ok(())
+        }
+        Ok(_) => {
+            debug!(
+                program = Grok::ID,
+                action = "unchanged",
+                path = %path.display(),
+                "preserving managed configuration not owned by Agentdesktop"
+            );
+            plan.record(Grok::DISPLAY_NAME, "configuration", "unchanged", path);
+            Ok(())
+        }
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            debug!(
+                program = Grok::ID,
+                action = "unchanged",
+                path = %path.display(),
+                "managed configuration already absent"
+            );
+            plan.record(Grok::DISPLAY_NAME, "configuration", "unchanged", path);
+            Ok(())
+        }
+        Err(error) => Err(error)
+            .with_context(|| format!("read Grok managed configuration from {}", path.display())),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::Path;
+
+    use agentdesktop_core::config::parse_daemon;
+
+    use super::managed_config;
+
+    #[test]
+    fn pass_through_settings_are_merged_with_managed_gateway_values() {
+        let config = parse_daemon(
+            r#"
+llmGateway:
+  url: https://gateway.example.com/proxy
+  authentication:
+    type: controllerJwt
+    audience: agentgateway
+    allowedClientIds: [grok]
+programs:
+  grok:
+    model: grok-4.6
+    models:
+      grok-4.6:
+        name: Company Grok
+        context_window: 128000
+        model: ignored-until-overlay
+      qwen:
+        name: Qwen
+        model: Qwen/Qwen3
+    managedConfig:
+      features:
+        telemetry: false
+      models:
+        default: ignored
+"#,
+        )
+        .expect("valid daemon configuration");
+        let grok = config.programs.grok.as_ref().unwrap();
+        let gateway = config.llm_gateway.as_ref().unwrap();
+
+        let settings = managed_config(
+            grok,
+            Some(gateway),
+            Path::new("/usr/local/bin/agentdesktop"),
+            Path::new("/run/agentdesktop/agentdesktop.sock"),
+        )
+        .expect("merged settings");
+
+        assert_eq!(settings["features"]["telemetry"], false);
+        assert_eq!(settings["models"]["default"], "grok-4.6");
+        let model = &settings["model"]["grok-4.6"];
+        assert_eq!(model["name"], "Company Grok");
+        assert_eq!(model["context_window"], 128000);
+        assert_eq!(model["base_url"], "https://gateway.example.com/proxy/v1");
+        assert_eq!(model["auth_provider"], "agentdesktop");
+        assert_eq!(settings["model"]["qwen"]["model"], "Qwen/Qwen3");
+        assert_eq!(
+            settings["model"]["qwen"]["base_url"],
+            "https://gateway.example.com/proxy/v1"
+        );
+        let provider = &settings["auth_provider"]["agentdesktop"];
+        assert_eq!(provider["command"], "/usr/local/bin/agentdesktop");
+        assert_eq!(provider["args"].as_array().unwrap().len(), 5);
+        assert_eq!(provider["args"][3], "--client-id");
+        assert_eq!(provider["args"][4], "grok");
+        assert_eq!(provider["timeout_secs"], 5);
+
+        let serialized = toml::to_string_pretty(&settings).expect("valid TOML");
+        let parsed: toml::Value = toml::from_str(&serialized).expect("parse generated TOML");
+        assert_eq!(parsed["models"]["default"].as_str(), Some("grok-4.6"));
+        assert_eq!(
+            parsed["auth_provider"]["agentdesktop"]["command"].as_str(),
+            Some("/usr/local/bin/agentdesktop")
+        );
+    }
+
+    #[test]
+    fn generates_a_catalog_entry_when_models_is_omitted() {
+        let config = parse_daemon(
+            r#"
+llmGateway:
+  url: http://127.0.0.1:4000
+programs:
+  grok:
+    model: grok-4.6
+"#,
+        )
+        .expect("valid daemon configuration");
+        let settings = managed_config(
+            config.programs.grok.as_ref().unwrap(),
+            config.llm_gateway.as_ref(),
+            Path::new("agentdesktop"),
+            Path::new("agentdesktop.sock"),
+        )
+        .expect("generated catalog");
+
+        assert_eq!(settings["models"]["default"], "grok-4.6");
+        assert_eq!(settings["model"]["grok-4.6"]["model"], "grok-4.6");
+        assert_eq!(settings["model"]["grok-4.6"]["name"], "Agentdesktop");
+        assert_eq!(
+            settings["model"]["grok-4.6"]["base_url"],
+            "http://127.0.0.1:4000/v1"
+        );
+        assert!(settings.get("auth_provider").is_none());
+    }
+
+    #[test]
+    fn oidc_uses_a_longer_credential_helper_timeout() {
+        let config = parse_daemon(
+            r#"
+llmGateway:
+  url: http://127.0.0.1:4001
+  authentication:
+    type: oidc
+    issuer: http://127.0.0.1:5557/dex
+    clientId: agentdesktop-local
+    allowInsecure: true
+programs:
+  grok:
+    model: grok-4.6
+"#,
+        )
+        .expect("valid daemon configuration");
+        let settings = managed_config(
+            config.programs.grok.as_ref().unwrap(),
+            config.llm_gateway.as_ref(),
+            Path::new("/bin/agentdesktop"),
+            Path::new("/tmp/agentdesktop.sock"),
+        )
+        .expect("oidc settings");
+
+        assert_eq!(
+            settings["auth_provider"]["agentdesktop"]["timeout_secs"],
+            600
+        );
+    }
+}

--- a/crates/agent/src/reconcile/mod.rs
+++ b/crates/agent/src/reconcile/mod.rs
@@ -289,6 +289,55 @@ programs:
     }
 
     #[test]
+    fn user_mode_rejects_grok_before_writing_other_settings() {
+        let root = std::env::temp_dir().join(format!(
+            "agentdesktop-reconcile-user-grok-{}-{}",
+            std::process::id(),
+            rand::random::<u64>()
+        ));
+        let config = parse_daemon(
+            r#"
+programs:
+  claudeCode: {}
+  grok: {}
+"#,
+        )
+        .unwrap();
+        let reconciler = Reconciler::new(
+            true,
+            root.join("claude/settings.json"),
+            root.join("claude-desktop/settings.json"),
+            root.join("claude-desktop/helper"),
+            root.join("codex/config.toml"),
+            root.join("opencode/config.json"),
+            root.join("opencode/plugin.js"),
+            root.join("grok/managed_config.toml"),
+            root.join("bin/agentdesktop"),
+            root.join("agentdesktop.sock"),
+        );
+
+        let error = reconciler.apply(&config).expect_err("user mode must fail");
+        assert!(error.to_string().contains("Grok Build"));
+        assert!(!root.exists(), "preflight failure must not write any files");
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn windows_rejects_system_grok_before_writing_other_settings() {
+        let fixture = Fixture::new();
+        let config = parse_daemon("programs:\n  claudeCode: {}\n  grok: {}\n").unwrap();
+        let error = fixture
+            .reconciler
+            .apply(&config)
+            .expect_err("Windows must fail");
+        assert!(error.to_string().contains("Windows"));
+        assert!(
+            !fixture.root.exists(),
+            "preflight failure must not write any files"
+        );
+    }
+
+    #[test]
     fn dry_run_plans_create_update_and_remove_without_changing_files() {
         let root = std::env::temp_dir().join(format!(
             "agentdesktop-reconcile-dry-run-{}-{}",
@@ -403,6 +452,12 @@ programs:
 "#,
         )
         .unwrap();
+        #[cfg(windows)]
+        let config = {
+            let mut config = config;
+            config.programs.grok = None;
+            config
+        };
         let plan = fixture.reconciler.plan(&config).unwrap();
         assert!(
             !fixture.root.exists(),
@@ -421,6 +476,7 @@ programs:
             "codex/config.toml",
             "opencode/config.json",
             "opencode/plugin.js",
+            #[cfg(unix)]
             "grok/managed_config.toml",
         ];
         let contents: Vec<_> = paths

--- a/crates/agent/src/reconcile/mod.rs
+++ b/crates/agent/src/reconcile/mod.rs
@@ -23,6 +23,7 @@ pub use crate::provider::{
         default_claude_desktop_credential_helper_path, default_claude_desktop_managed_settings_path,
     },
     codex::default_codex_managed_config_path,
+    grok::default_grok_managed_config_path,
     opencode::{default_open_code_managed_config_path, default_open_code_plugin_path},
 };
 
@@ -42,6 +43,7 @@ impl Reconciler {
         codex_managed_config_path: PathBuf,
         open_code_managed_config_path: PathBuf,
         open_code_plugin_path: PathBuf,
+        grok_managed_config_path: PathBuf,
         credential_helper: PathBuf,
         socket: PathBuf,
     ) -> Self {
@@ -68,7 +70,9 @@ impl Reconciler {
                 }),
                 Box::new(VsCode),
                 Box::new(Cursor),
-                Box::new(Grok),
+                Box::new(Grok {
+                    managed_config_path: grok_managed_config_path,
+                }),
                 Box::new(Ollama),
             ]),
         }
@@ -269,6 +273,7 @@ programs:
             root.join("codex/config.toml"),
             root.join("opencode/config.json"),
             root.join("opencode/plugin.js"),
+            root.join("grok/managed_config.toml"),
             root.join("bin/agentdesktop"),
             root.join("agentdesktop.sock"),
         );
@@ -319,6 +324,7 @@ programs:
             root.join("codex/config.toml"),
             root.join("opencode/config.json"),
             root.join("opencode/plugin.js"),
+            root.join("grok/managed_config.toml"),
             root.join("bin/agentdesktop"),
             root.join("agentdesktop.sock"),
         );
@@ -359,6 +365,7 @@ programs:
                 root.join("codex/config.toml"),
                 root.join("opencode/config.json"),
                 root.join("opencode/plugin.js"),
+                root.join("grok/managed_config.toml"),
                 root.join("bin/agentdesktop"),
                 root.join("agentdesktop.sock"),
             );
@@ -382,7 +389,7 @@ llmGateway:
   authentication:
     type: controllerJwt
     audience: agentgateway
-    allowedClientIds: [claude-code, claude-desktop, codex, opencode]
+    allowedClientIds: [claude-code, claude-desktop, codex, opencode, grok]
 programs:
   claudeCode: {}
   claudeDesktop: {}
@@ -391,6 +398,8 @@ programs:
     model: company-model
     models:
       company-model: {}
+  grok:
+    model: grok-4.6
 "#,
         )
         .unwrap();
@@ -412,6 +421,7 @@ programs:
             "codex/config.toml",
             "opencode/config.json",
             "opencode/plugin.js",
+            "grok/managed_config.toml",
         ];
         let contents: Vec<_> = paths
             .iter()

--- a/crates/agent/src/reconcile/mod.rs
+++ b/crates/agent/src/reconcile/mod.rs
@@ -323,18 +323,11 @@ programs:
 
     #[cfg(windows)]
     #[test]
-    fn windows_rejects_system_grok_before_writing_other_settings() {
+    fn windows_reconciles_system_grok_managed_config() {
         let fixture = Fixture::new();
         let config = parse_daemon("programs:\n  claudeCode: {}\n  grok: {}\n").unwrap();
-        let error = fixture
-            .reconciler
-            .apply(&config)
-            .expect_err("Windows must fail");
-        assert!(error.to_string().contains("Windows"));
-        assert!(
-            !fixture.root.exists(),
-            "preflight failure must not write any files"
-        );
+        fixture.reconciler.apply(&config).unwrap();
+        assert!(fixture.root.join("grok/managed_config.toml").exists());
     }
 
     #[test]
@@ -452,12 +445,6 @@ programs:
 "#,
         )
         .unwrap();
-        #[cfg(windows)]
-        let config = {
-            let mut config = config;
-            config.programs.grok = None;
-            config
-        };
         let plan = fixture.reconciler.plan(&config).unwrap();
         assert!(
             !fixture.root.exists(),
@@ -476,7 +463,6 @@ programs:
             "codex/config.toml",
             "opencode/config.json",
             "opencode/plugin.js",
-            #[cfg(unix)]
             "grok/managed_config.toml",
         ];
         let contents: Vec<_> = paths

--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -379,6 +379,9 @@ pub struct ProgramsConfig {
     /// OpenCode managed configuration.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub open_code: Option<OpenCodeConfig>,
+    /// Grok Build managed configuration.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub grok: Option<GrokConfig>,
 }
 
 impl ProgramsConfig {
@@ -387,6 +390,7 @@ impl ProgramsConfig {
             && self.claude_desktop.is_none()
             && self.codex.is_none()
             && self.open_code.is_none()
+            && self.grok.is_none()
     }
 }
 
@@ -472,6 +476,39 @@ pub struct OpenCodeConfig {
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
     pub models: BTreeMap<String, serde_json::Value>,
     /// Arbitrary values written to OpenCode's system-managed configuration.
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub managed_config: BTreeMap<String, serde_json::Value>,
+}
+
+/// Settings reconciled into Grok Build's organization-managed configuration.
+///
+/// Values under `managedConfig` are written to Grok's `managed_config.toml`.
+/// When generated LLM-gateway settings overlap with those values,
+/// Agentdesktop's generated values take precedence.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct GrokConfig {
+    /// Whether this program uses the top-level LLM gateway.
+    #[serde(default = "default_true", skip_serializing_if = "is_true")]
+    pub use_llm_gateway: bool,
+    /// Catalog ID and API model used when pointing Grok at the LLM gateway.
+    ///
+    /// This is required when a top-level `llmGateway` is configured. If `models`
+    /// is empty, Agentdesktop creates a catalog entry with this ID.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub model: Option<String>,
+    /// Extra Grok `[model.<id>]` catalog entries, keyed by catalog ID.
+    ///
+    /// Each value is an arbitrary Grok model object. Generated gateway
+    /// `base_url` and `auth_provider` values take precedence. When this map is
+    /// non-empty, `model` must name one of its keys.
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub models: BTreeMap<String, serde_json::Value>,
+    /// Arbitrary values written to Grok's organization-managed TOML configuration.
+    ///
+    /// Use Grok's native snake_case configuration keys. TOML has no null value,
+    /// so null values cannot be reconciled.
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
     pub managed_config: BTreeMap<String, serde_json::Value>,
 }
@@ -603,6 +640,9 @@ fn validate_daemon(
         if programs.open_code.is_some() {
             anyhow::bail!("sandbox is not supported for OpenCode");
         }
+        if programs.grok.is_some() {
+            anyhow::bail!("sandbox is not supported for Grok Build");
+        }
     }
     if let Some(gateway) = llm_gateway {
         if !matches!(gateway.url.scheme(), "http" | "https") {
@@ -731,6 +771,19 @@ fn validate_daemon(
             .context("OpenCode requires model when llmGateway is configured")?;
         if !open_code.models.contains_key(model) {
             anyhow::bail!("OpenCode model {model} is not declared in models");
+        }
+    }
+    if let Some(grok) = &programs.grok
+        && llm_gateway.is_some()
+        && grok.use_llm_gateway
+    {
+        let model = grok
+            .model
+            .as_deref()
+            .filter(|model| !model.trim().is_empty())
+            .context("Grok Build requires model when llmGateway is configured")?;
+        if !grok.models.is_empty() && !grok.models.contains_key(model) {
+            anyhow::bail!("Grok Build model {model} is not declared in models");
         }
     }
     Ok(())
@@ -1038,6 +1091,47 @@ programs:
             error
                 .to_string()
                 .contains("OpenCode model missing is not declared in models")
+        );
+    }
+
+    #[test]
+    fn grok_requires_a_model_when_using_the_gateway() {
+        let error = parse_daemon(
+            r#"
+llmGateway:
+  url: https://gateway.example.com
+programs:
+  grok: {}
+"#,
+        )
+        .expect_err("Grok without a model should fail");
+
+        assert!(
+            error
+                .to_string()
+                .contains("Grok Build requires model when llmGateway is configured")
+        );
+    }
+
+    #[test]
+    fn grok_requires_a_declared_gateway_model_when_models_are_listed() {
+        let error = parse_daemon(
+            r#"
+llmGateway:
+  url: https://gateway.example.com
+programs:
+  grok:
+    model: missing
+    models:
+      available: {}
+"#,
+        )
+        .expect_err("undeclared Grok model should fail");
+
+        assert!(
+            error
+                .to_string()
+                .contains("Grok Build model missing is not declared in models")
         );
     }
 }

--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -485,8 +485,8 @@ pub struct OpenCodeConfig {
 /// Values under `managedConfig` are written to Grok's `managed_config.toml`.
 /// When generated LLM-gateway settings overlap with those values,
 /// agentdesktop's generated values take precedence.
-/// Only system mode on Linux and macOS is supported. Grok can delete or replace
-/// the user-level managed file during startup, so `--user` rejects `programs.grok`.
+/// Only system mode is supported. Grok can delete or replace the user-level
+/// managed file during startup, so `--user` rejects `programs.grok`.
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]

--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -485,6 +485,8 @@ pub struct OpenCodeConfig {
 /// Values under `managedConfig` are written to Grok's `managed_config.toml`.
 /// When generated LLM-gateway settings overlap with those values,
 /// Agentdesktop's generated values take precedence.
+/// Only system mode on Linux and macOS is supported. Grok can delete or replace
+/// the user-level managed file during startup, so `--user` rejects `programs.grok`.
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
@@ -501,8 +503,10 @@ pub struct GrokConfig {
     /// Extra Grok `[model.<id>]` catalog entries, keyed by catalog ID.
     ///
     /// Each value is an arbitrary Grok model object. Generated gateway
-    /// `base_url` and `auth_provider` values take precedence. When this map is
-    /// non-empty, `model` must name one of its keys.
+    /// `base_url` and `auth_provider` values take precedence. When gateway
+    /// authentication is configured, `api_key` and `env_key` are removed from
+    /// these entries, including values supplied through `managedConfig`.
+    /// When this map is non-empty, `model` must name one of its keys.
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
     pub models: BTreeMap<String, serde_json::Value>,
     /// Arbitrary values written to Grok's organization-managed TOML configuration.

--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -484,7 +484,7 @@ pub struct OpenCodeConfig {
 ///
 /// Values under `managedConfig` are written to Grok's `managed_config.toml`.
 /// When generated LLM-gateway settings overlap with those values,
-/// Agentdesktop's generated values take precedence.
+/// agentdesktop's generated values take precedence.
 /// Only system mode on Linux and macOS is supported. Grok can delete or replace
 /// the user-level managed file during startup, so `--user` rejects `programs.grok`.
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -497,7 +497,7 @@ pub struct GrokConfig {
     /// Catalog ID and API model used when pointing Grok at the LLM gateway.
     ///
     /// This is required when a top-level `llmGateway` is configured. If `models`
-    /// is empty, Agentdesktop creates a catalog entry with this ID.
+    /// is empty, agentdesktop creates a catalog entry with this ID.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub model: Option<String>,
     /// Extra Grok `[model.<id>]` catalog entries, keyed by catalog ID.

--- a/frontend/controller/src/types.ts
+++ b/frontend/controller/src/types.ts
@@ -69,7 +69,12 @@ export type ControllerSettings = {
   gateway_jwt_enabled: boolean;
 };
 
-export type AgentKind = "claudeCode" | "claudeDesktop" | "codex" | "openCode";
+export type AgentKind =
+  | "claudeCode"
+  | "claudeDesktop"
+  | "codex"
+  | "openCode"
+  | "grok";
 
 export type AgentDraft = {
   kind: AgentKind;

--- a/frontend/controller/src/views/ConfigurationView.tsx
+++ b/frontend/controller/src/views/ConfigurationView.tsx
@@ -520,11 +520,19 @@ const configurableAgents: Array<{
     initialSettings:
       "model: gpt-5.6-terra\nmodels:\n  gpt-5.6-terra:\n    name: GPT 5.6 Terra",
   },
+  {
+    kind: "grok",
+    label: "Grok Build",
+    iconKind: "grok",
+    placeholder: "model: grok-4.6",
+    initialSettings: "model: grok-4.6",
+  },
 ];
 
 const sandboxUnsupportedAgents = new Set<AgentKind>([
   "claudeDesktop",
   "openCode",
+  "grok",
 ]);
 
 function daemonConfigYaml(options: {
@@ -549,7 +557,7 @@ function daemonConfigYaml(options: {
         "  authentication:",
         "    type: controllerJwt",
         `    audience: ${yamlString(options.audience)}`,
-        "    allowedClientIds: [claude-code, claude-desktop, codex, opencode]",
+        "    allowedClientIds: [claude-code, claude-desktop, codex, opencode, grok]",
       );
     }
     lines.push("");

--- a/frontend/controller/src/views/ConfigurationView.tsx
+++ b/frontend/controller/src/views/ConfigurationView.tsx
@@ -478,7 +478,8 @@ export function ConfigurationView({
               {copied ? "Copied" : "Copy"}
             </button>
           </div>
-          <pre>
+          {/* biome-ignore lint/a11y/noNoninteractiveTabindex: Keyboard users need to focus this scrollable preview. */}
+          <pre tabIndex={0}>
             <code>{yaml}</code>
           </pre>
         </section>

--- a/schema/daemon-config.json
+++ b/schema/daemon-config.json
@@ -134,6 +134,34 @@
         "address"
       ]
     },
+    "GrokConfig": {
+      "description": "Settings reconciled into Grok Build's organization-managed configuration.\n\nValues under `managedConfig` are written to Grok's `managed_config.toml`.\nWhen generated LLM-gateway settings overlap with those values,\nAgentdesktop's generated values take precedence.",
+      "type": "object",
+      "properties": {
+        "managedConfig": {
+          "description": "Arbitrary values written to Grok's organization-managed TOML configuration.\n\nUse Grok's native snake_case configuration keys. TOML has no null value,\nso null values cannot be reconciled.",
+          "type": "object",
+          "additionalProperties": true
+        },
+        "model": {
+          "description": "Catalog ID and API model used when pointing Grok at the LLM gateway.\n\nThis is required when a top-level `llmGateway` is configured. If `models`\nis empty, Agentdesktop creates a catalog entry with this ID.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "models": {
+          "description": "Extra Grok `[model.<id>]` catalog entries, keyed by catalog ID.\n\nEach value is an arbitrary Grok model object. Generated gateway\n`base_url` and `auth_provider` values take precedence. When this map is\nnon-empty, `model` must name one of its keys.",
+          "type": "object",
+          "additionalProperties": true
+        },
+        "useLlmGateway": {
+          "description": "Whether this program uses the top-level LLM gateway.",
+          "type": "boolean"
+        }
+      },
+      "additionalProperties": false
+    },
     "LlmGatewayAuthentication": {
       "description": "Authentication mechanisms supported by an LLM gateway.",
       "oneOf": [
@@ -306,6 +334,17 @@
           "anyOf": [
             {
               "$ref": "#/$defs/CodexConfig"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "grok": {
+          "description": "Grok Build managed configuration.",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/GrokConfig"
             },
             {
               "type": "null"

--- a/schema/daemon-config.json
+++ b/schema/daemon-config.json
@@ -135,7 +135,7 @@
       ]
     },
     "GrokConfig": {
-      "description": "Settings reconciled into Grok Build's organization-managed configuration.\n\nValues under `managedConfig` are written to Grok's `managed_config.toml`.\nWhen generated LLM-gateway settings overlap with those values,\nAgentdesktop's generated values take precedence.\nOnly system mode on Linux and macOS is supported. Grok can delete or replace\nthe user-level managed file during startup, so `--user` rejects `programs.grok`.",
+      "description": "Settings reconciled into Grok Build's organization-managed configuration.\n\nValues under `managedConfig` are written to Grok's `managed_config.toml`.\nWhen generated LLM-gateway settings overlap with those values,\nagentdesktop's generated values take precedence.\nOnly system mode on Linux and macOS is supported. Grok can delete or replace\nthe user-level managed file during startup, so `--user` rejects `programs.grok`.",
       "type": "object",
       "properties": {
         "managedConfig": {
@@ -144,7 +144,7 @@
           "additionalProperties": true
         },
         "model": {
-          "description": "Catalog ID and API model used when pointing Grok at the LLM gateway.\n\nThis is required when a top-level `llmGateway` is configured. If `models`\nis empty, Agentdesktop creates a catalog entry with this ID.",
+          "description": "Catalog ID and API model used when pointing Grok at the LLM gateway.\n\nThis is required when a top-level `llmGateway` is configured. If `models`\nis empty, agentdesktop creates a catalog entry with this ID.",
           "type": [
             "string",
             "null"

--- a/schema/daemon-config.json
+++ b/schema/daemon-config.json
@@ -135,7 +135,7 @@
       ]
     },
     "GrokConfig": {
-      "description": "Settings reconciled into Grok Build's organization-managed configuration.\n\nValues under `managedConfig` are written to Grok's `managed_config.toml`.\nWhen generated LLM-gateway settings overlap with those values,\nagentdesktop's generated values take precedence.\nOnly system mode on Linux and macOS is supported. Grok can delete or replace\nthe user-level managed file during startup, so `--user` rejects `programs.grok`.",
+      "description": "Settings reconciled into Grok Build's organization-managed configuration.\n\nValues under `managedConfig` are written to Grok's `managed_config.toml`.\nWhen generated LLM-gateway settings overlap with those values,\nagentdesktop's generated values take precedence.\nOnly system mode is supported. Grok can delete or replace the user-level\nmanaged file during startup, so `--user` rejects `programs.grok`.",
       "type": "object",
       "properties": {
         "managedConfig": {

--- a/schema/daemon-config.json
+++ b/schema/daemon-config.json
@@ -135,7 +135,7 @@
       ]
     },
     "GrokConfig": {
-      "description": "Settings reconciled into Grok Build's organization-managed configuration.\n\nValues under `managedConfig` are written to Grok's `managed_config.toml`.\nWhen generated LLM-gateway settings overlap with those values,\nAgentdesktop's generated values take precedence.",
+      "description": "Settings reconciled into Grok Build's organization-managed configuration.\n\nValues under `managedConfig` are written to Grok's `managed_config.toml`.\nWhen generated LLM-gateway settings overlap with those values,\nAgentdesktop's generated values take precedence.\nOnly system mode on Linux and macOS is supported. Grok can delete or replace\nthe user-level managed file during startup, so `--user` rejects `programs.grok`.",
       "type": "object",
       "properties": {
         "managedConfig": {
@@ -151,7 +151,7 @@
           ]
         },
         "models": {
-          "description": "Extra Grok `[model.<id>]` catalog entries, keyed by catalog ID.\n\nEach value is an arbitrary Grok model object. Generated gateway\n`base_url` and `auth_provider` values take precedence. When this map is\nnon-empty, `model` must name one of its keys.",
+          "description": "Extra Grok `[model.<id>]` catalog entries, keyed by catalog ID.\n\nEach value is an arbitrary Grok model object. Generated gateway\n`base_url` and `auth_provider` values take precedence. When gateway\nauthentication is configured, `api_key` and `env_key` are removed from\nthese entries, including values supplied through `managedConfig`.\nWhen this map is non-empty, `model` must name one of its keys.",
           "type": "object",
           "additionalProperties": true
         },

--- a/schema/daemon-config.md
+++ b/schema/daemon-config.md
@@ -28,6 +28,11 @@
 |`programs.codex`|object|Codex managed configuration.|
 |`programs.codex.managedConfig`|object|Arbitrary values written to Codex's organization-managed TOML configuration.<br><br>Use Codex's native snake_case configuration keys. TOML has no null value,<br>so null values cannot be reconciled.|
 |`programs.codex.useLlmGateway`|boolean|Whether this program uses the top-level LLM gateway.|
+|`programs.grok`|object|Grok Build managed configuration.|
+|`programs.grok.managedConfig`|object|Arbitrary values written to Grok's organization-managed TOML configuration.<br><br>Use Grok's native snake_case configuration keys. TOML has no null value,<br>so null values cannot be reconciled.|
+|`programs.grok.model`|string|Catalog ID and API model used when pointing Grok at the LLM gateway.<br><br>This is required when a top-level `llmGateway` is configured. If `models`<br>is empty, Agentdesktop creates a catalog entry with this ID.|
+|`programs.grok.models`|object|Extra Grok `[model.<id>]` catalog entries, keyed by catalog ID.<br><br>Each value is an arbitrary Grok model object. Generated gateway<br>`base_url` and `auth_provider` values take precedence. When this map is<br>non-empty, `model` must name one of its keys.|
+|`programs.grok.useLlmGateway`|boolean|Whether this program uses the top-level LLM gateway.|
 |`programs.openCode`|object|OpenCode managed configuration.|
 |`programs.openCode.managedConfig`|object|Arbitrary values written to OpenCode's system-managed configuration.|
 |`programs.openCode.model`|string|Model ID selected from `models` when using the LLM gateway.<br><br>This is required when a top-level `llmGateway` is configured.|

--- a/schema/daemon-config.md
+++ b/schema/daemon-config.md
@@ -31,7 +31,7 @@
 |`programs.grok`|object|Grok Build managed configuration.|
 |`programs.grok.managedConfig`|object|Arbitrary values written to Grok's organization-managed TOML configuration.<br><br>Use Grok's native snake_case configuration keys. TOML has no null value,<br>so null values cannot be reconciled.|
 |`programs.grok.model`|string|Catalog ID and API model used when pointing Grok at the LLM gateway.<br><br>This is required when a top-level `llmGateway` is configured. If `models`<br>is empty, Agentdesktop creates a catalog entry with this ID.|
-|`programs.grok.models`|object|Extra Grok `[model.<id>]` catalog entries, keyed by catalog ID.<br><br>Each value is an arbitrary Grok model object. Generated gateway<br>`base_url` and `auth_provider` values take precedence. When this map is<br>non-empty, `model` must name one of its keys.|
+|`programs.grok.models`|object|Extra Grok `[model.<id>]` catalog entries, keyed by catalog ID.<br><br>Each value is an arbitrary Grok model object. Generated gateway<br>`base_url` and `auth_provider` values take precedence. When gateway<br>authentication is configured, `api_key` and `env_key` are removed from<br>these entries, including values supplied through `managedConfig`.<br>When this map is non-empty, `model` must name one of its keys.|
 |`programs.grok.useLlmGateway`|boolean|Whether this program uses the top-level LLM gateway.|
 |`programs.openCode`|object|OpenCode managed configuration.|
 |`programs.openCode.managedConfig`|object|Arbitrary values written to OpenCode's system-managed configuration.|

--- a/schema/daemon-config.md
+++ b/schema/daemon-config.md
@@ -30,7 +30,7 @@
 |`programs.codex.useLlmGateway`|boolean|Whether this program uses the top-level LLM gateway.|
 |`programs.grok`|object|Grok Build managed configuration.|
 |`programs.grok.managedConfig`|object|Arbitrary values written to Grok's organization-managed TOML configuration.<br><br>Use Grok's native snake_case configuration keys. TOML has no null value,<br>so null values cannot be reconciled.|
-|`programs.grok.model`|string|Catalog ID and API model used when pointing Grok at the LLM gateway.<br><br>This is required when a top-level `llmGateway` is configured. If `models`<br>is empty, Agentdesktop creates a catalog entry with this ID.|
+|`programs.grok.model`|string|Catalog ID and API model used when pointing Grok at the LLM gateway.<br><br>This is required when a top-level `llmGateway` is configured. If `models`<br>is empty, agentdesktop creates a catalog entry with this ID.|
 |`programs.grok.models`|object|Extra Grok `[model.<id>]` catalog entries, keyed by catalog ID.<br><br>Each value is an arbitrary Grok model object. Generated gateway<br>`base_url` and `auth_provider` values take precedence. When gateway<br>authentication is configured, `api_key` and `env_key` are removed from<br>these entries, including values supplied through `managedConfig`.<br>When this map is non-empty, `model` must name one of its keys.|
 |`programs.grok.useLlmGateway`|boolean|Whether this program uses the top-level LLM gateway.|
 |`programs.openCode`|object|OpenCode managed configuration.|


### PR DESCRIPTION
Adds `programs.grok` reconciliation on top of the Grok Build discovery support from #72. The daemon manages Grok's system `managed_config.toml` on Linux, macOS, and Windows, routes configured model catalog entries to the LLM gateway, and configures a named `auth_provider` that invokes the agentdesktop credential helper with `--client-id grok`.

Default managed-config paths:

- Linux/macOS: `/etc/grok/managed_config.toml`
- Windows: `%SystemDrive%\etc\grok\managed_config.toml` (`C:\etc\grok\managed_config.toml` fallback)

```yaml
llmGateway:
  url: http://127.0.0.1:4000
  authentication:
    type: controllerJwt
    audience: agentgateway
    allowedClientIds: [claude-code, claude-desktop, codex, opencode, grok]
programs:
  grok:
    model: grok-4.6
```

`model` is required when Grok uses the gateway. An omitted `models` map creates the default catalog entry; an explicit map must contain the selected model. Native TOML settings can be supplied through `managedConfig`. Generated gateway values take precedence. When gateway authentication is configured, static `api_key` and `env_key` fields are removed from managed catalog entries, including pass-through values, because Grok otherwise skips the credential helper.

Management is system-mode only. Grok can delete or replace its user-level `managed_config.toml` during startup, so `--user` rejects `programs.grok` during planning before any provider writes files. Discovery remains available. Unowned files are preserved, and owned configuration supports dry run, repeat reconciliation, and cleanup.

The controller configuration builder now includes Grok. Its scrollable YAML preview is keyboard-focusable, resolving the seven accessibility failures triggered by the longer client allowlist.

Validation:

- 89 local Rust library tests passed (`agentdesktop-core` and `agentdesktop-agent`), including credential precedence, user-mode rejection before writes, and Windows managed-config path coverage.
- Rust formatting and Clippy passed for the affected crates and their targets; schemas regenerated.
- All 32 controller Storybook tests, frontend lint, typecheck, and production build passed.
- Native Grok 1.0.24 smoke test: generated TOML loaded without warnings; Grok invoked the real agentdesktop credential CLI against fixture IPC and sent its token to a local gateway, receiving a successful response. The isolated user-home test used `GROK_MANAGED_CONFIG=0` to prevent Grok's cleanup; the cleanup was reproduced without that setting.
- PR #73 GitHub checks passed on the latest commit, including Windows agent tests.

Sandbox translation, telemetry hooks, and `requirements.toml` enforcement remain out of scope.
