### PR TITLE
feat(agent): discover Cursor and stop reporting forks as VS Code

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Agentdesktop discovers AI developer tools, inventories MCP servers and skills,
 applies tool-native configuration and sandbox policy, and connects each device
 to an LLM gateway with user and device identity.
 
-Keep developers in Claude Code, Codex, OpenCode, and VS Code while giving
+Keep developers in Claude Code, Codex, Cursor, OpenCode, and VS Code while giving
 platform teams one place to understand and manage the fleet.
 
 [Website](https://agentdesktop.dev) ·
@@ -133,6 +133,7 @@ stage.
 | Claude Code | Yes | Yes | MCP and skills | Yes |
 | Claude Desktop | Yes | Yes | MCP | — |
 | Codex | Yes | Yes | MCP and skills | Yes |
+| Cursor | Yes | — | MCP and skills | — |
 | OpenCode | Yes | Yes | MCP | — |
 | VS Code | Yes | — | MCP and skills | — |
 

--- a/crates/agent/src/provider/README.md
+++ b/crates/agent/src/provider/README.md
@@ -4,18 +4,18 @@ Features currently implemented by Agentdesktop.
 
 ✅ Implemented · ◯ Not implemented · — Not applicable
 
-| Feature | [Claude Code](claude_code/) | [Claude Desktop](claude_desktop/) | [Codex](codex/) | [OpenCode](opencode/) | [VS Code](vscode/) | [Ollama](ollama/) |
-| --- | :---: | :---: | :---: | :---: | :---: | :---: |
-| Installation and version discovery | ✅ | ✅ | ✅ | ✅ | ✅ | — |
-| Local model discovery | — | — | — | — | — | ✅ |
-| MCP server discovery | ✅ | ✅ | ✅ | ◯ | ✅ | — |
-| Skill discovery | ✅ | ◯ | ✅ | ◯ | ✅ | — |
-| Managed configuration | ✅ | ✅ | ✅ | ✅ | ◯ | ◯ |
-| LLM gateway routing | ✅ | ✅ | ✅ | ✅ | ◯ | — |
-| Gateway credentials | ✅ | ✅ | ✅ | ✅ | ◯ | — |
-| Sandbox configuration | ✅ | ◯ | ✅ | ◯ | ◯ | — |
-| Tool-use telemetry | ✅ | ◯ | ◯ | ◯ | ◯ | — |
-| Session-start telemetry | ✅ | ◯ | ◯ | ◯ | ◯ | — |
+| Feature | [Claude Code](claude_code/) | [Claude Desktop](claude_desktop/) | [Codex](codex/) | [OpenCode](opencode/) | [VS Code](vscode/) | [Ollama](ollama/) | [Cursor](cursor/) |
+| --- | :---: | :---: | :---: | :---: | :---: | :---: | :---: |
+| Installation and version discovery | ✅ | ✅ | ✅ | ✅ | ✅ | — | ✅ |
+| Local model discovery | — | — | — | — | — | ✅ | — |
+| MCP server discovery | ✅ | ✅ | ✅ | ◯ | ✅ | — | ✅ |
+| Skill discovery | ✅ | ◯ | ✅ | ◯ | ✅ | — | ✅ |
+| Managed configuration | ✅ | ✅ | ✅ | ✅ | ◯ | ◯ | ◯ |
+| LLM gateway routing | ✅ | ✅ | ✅ | ✅ | ◯ | — | ◯ |
+| Gateway credentials | ✅ | ✅ | ✅ | ✅ | ◯ | — | ◯ |
+| Sandbox configuration | ✅ | ◯ | ✅ | ◯ | ◯ | — | ◯ |
+| Tool-use telemetry | ✅ | ◯ | ◯ | ◯ | ◯ | — | ◯ |
+| Session-start telemetry | ✅ | ◯ | ◯ | ◯ | ◯ | — | ◯ |
 
 - ◯ describes a gap in Agentdesktop; it does not mean the upstream provider
   cannot support the feature.

--- a/crates/agent/src/provider/cursor/discovery.rs
+++ b/crates/agent/src/provider/cursor/discovery.rs
@@ -1,0 +1,245 @@
+use std::{
+    collections::BTreeSet,
+    path::{Path, PathBuf},
+};
+
+use agentdesktop_core::model::{Agent, McpServer};
+
+use super::Cursor;
+use crate::provider::{metadata, vscode::discovery as vscode};
+
+/// Product name recorded in Cursor's packaged `package.json`.
+const PRODUCT_NAME: &str = "Cursor";
+
+pub(super) fn discover() -> Option<Agent> {
+    let executable = metadata::find_all_in_path("cursor")
+        .into_iter()
+        .chain(
+            executable_candidates()
+                .into_iter()
+                .filter(|candidate| candidate.is_file()),
+        )
+        .find(|candidate| is_cursor(candidate))?;
+    // Only this install's own manifest, so an unrelated `cursor` on PATH cannot
+    // be reported carrying a version read out of a real Cursor elsewhere.
+    let version = metadata::packaged_manifest_candidates(&executable)
+        .into_iter()
+        .find_map(|path| metadata::json_package_version(&path, PRODUCT_NAME));
+    Some(Agent {
+        version,
+        executable,
+        kind: Cursor::ID.to_owned(),
+        mcp_servers: discover_mcp_servers(),
+        skills: metadata::discover_skills(skill_roots()),
+    })
+}
+
+/// Rejects a `cursor` launcher whose packaged manifest names a different
+/// product, mirroring the Visual Studio Code check.
+///
+/// A launcher with no manifest is still accepted, so packaging that does not
+/// expose one — a Linux AppImage, for instance — keeps being discovered.
+fn is_cursor(executable: &Path) -> bool {
+    metadata::packaged_manifest_candidates(executable)
+        .into_iter()
+        .find_map(|path| metadata::json_package_name(&path))
+        .is_none_or(|name| name == PRODUCT_NAME)
+}
+
+/// Cursor is a Visual Studio Code fork and reads the same MCP configuration
+/// schema, so the VS Code parser is reused against Cursor's own paths.
+fn discover_mcp_servers() -> Vec<McpServer> {
+    mcp_config_paths()
+        .into_iter()
+        .flat_map(|path| vscode::mcp_servers_from_json(&path))
+        .collect()
+}
+
+fn mcp_config_paths() -> Vec<PathBuf> {
+    let mut paths = BTreeSet::new();
+    for home in metadata::user_home_dirs() {
+        paths.insert(home.join(".cursor/mcp.json"));
+    }
+    paths.extend(metadata::current_dir_ancestors(Path::new(
+        ".cursor/mcp.json",
+    )));
+    paths.into_iter().collect()
+}
+
+/// Roots Cursor loads skills from, including the Claude Code and Codex
+/// directories it reads for compatibility.
+fn skill_roots() -> Vec<PathBuf> {
+    let mut roots = BTreeSet::new();
+    for relative in [
+        ".cursor/skills",
+        ".agents/skills",
+        ".claude/skills",
+        ".codex/skills",
+    ] {
+        roots.extend(metadata::current_dir_ancestors(Path::new(relative)));
+    }
+    for home in metadata::user_home_dirs() {
+        roots.insert(home.join(".cursor/skills"));
+        roots.insert(home.join(".agents/skills"));
+        roots.insert(home.join(".claude/skills"));
+        roots.insert(home.join(".codex/skills"));
+    }
+    roots.into_iter().collect()
+}
+
+fn executable_candidates() -> Vec<PathBuf> {
+    #[allow(unused_mut)]
+    let mut candidates = BTreeSet::new();
+
+    #[cfg(target_os = "macos")]
+    {
+        candidates.insert(PathBuf::from(
+            "/Applications/Cursor.app/Contents/Resources/app/bin/cursor",
+        ));
+        for home in metadata::user_home_dirs() {
+            candidates
+                .insert(home.join("Applications/Cursor.app/Contents/Resources/app/bin/cursor"));
+        }
+    }
+
+    #[cfg(target_os = "linux")]
+    {
+        candidates.extend([
+            PathBuf::from("/usr/share/cursor/bin/cursor"),
+            PathBuf::from("/usr/lib/cursor/bin/cursor"),
+            PathBuf::from("/opt/cursor/bin/cursor"),
+            PathBuf::from("/opt/Cursor/bin/cursor"),
+            PathBuf::from("/usr/local/bin/cursor"),
+        ]);
+        for home in metadata::user_home_dirs() {
+            candidates.insert(home.join(".local/bin/cursor"));
+        }
+    }
+
+    #[cfg(windows)]
+    {
+        for home in metadata::user_home_dirs() {
+            candidates
+                .insert(home.join("AppData/Local/Programs/Cursor/resources/app/bin/cursor.cmd"));
+            candidates
+                .insert(home.join("AppData/Local/Programs/Cursor/resources/app/bin/cursor.exe"));
+        }
+        for root in [
+            metadata::env_path("ProgramFiles"),
+            metadata::env_path("ProgramFiles(x86)"),
+        ]
+        .into_iter()
+        .flatten()
+        {
+            candidates.insert(root.join("Cursor/resources/app/bin/cursor.cmd"));
+            candidates.insert(root.join("Cursor/resources/app/bin/cursor.exe"));
+        }
+    }
+
+    candidates.into_iter().collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::{Path, PathBuf};
+
+    use serde_json::json;
+
+    use super::{mcp_config_paths, skill_roots};
+    use crate::provider::vscode::discovery::mcp_servers_from_value;
+
+    #[test]
+    fn reads_cursor_servers_without_secrets_or_arguments() {
+        let servers = mcp_servers_from_value(
+            &json!({
+                "mcpServers": {
+                    "notion": {
+                        "url": "https://mcp.notion.com/mcp",
+                        "headers": { "Authorization": "secret" }
+                    },
+                    "local": {
+                        "command": "npx",
+                        "args": ["-y", "secret-package"],
+                        "env": { "TOKEN": "secret" }
+                    }
+                }
+            }),
+            Path::new(".cursor/mcp.json"),
+        );
+
+        assert_eq!(servers.len(), 2);
+        assert_eq!(servers[0].name, "local");
+        assert_eq!(servers[0].transport, "stdio");
+        assert_eq!(servers[0].command.as_deref(), Some("npx"));
+        assert_eq!(servers[1].name, "notion");
+        assert_eq!(servers[1].transport, "http");
+        assert_eq!(
+            servers[1].url.as_deref(),
+            Some("https://mcp.notion.com/mcp")
+        );
+    }
+
+    #[test]
+    fn reads_the_user_level_mcp_configuration() {
+        assert!(
+            mcp_config_paths()
+                .iter()
+                .any(|path| path.ends_with(".cursor/mcp.json"))
+        );
+    }
+
+    #[test]
+    fn includes_the_compatibility_skill_roots_cursor_reads() {
+        let roots = skill_roots();
+        for relative in [
+            ".cursor/skills",
+            ".agents/skills",
+            ".claude/skills",
+            ".codex/skills",
+        ] {
+            assert!(
+                roots.iter().any(|root| root.ends_with(relative)),
+                "missing skill root {relative}"
+            );
+        }
+    }
+
+    #[test]
+    fn identifies_cursor_only_from_its_own_manifest() {
+        let root = std::env::temp_dir().join(format!("agentdesktop-cursor-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&root);
+        std::fs::create_dir_all(root.join("bin")).unwrap();
+        let launcher = root.join("bin/cursor");
+        std::fs::write(&launcher, "").unwrap();
+
+        // No manifest: still accepted, so AppImage-style packaging is found.
+        assert!(super::is_cursor(&launcher));
+
+        for (product, expected) in [("Code", false), ("Cursor", true)] {
+            std::fs::write(
+                root.join("package.json"),
+                json!({ "name": product, "version": "1.2.3" }).to_string(),
+            )
+            .unwrap();
+            assert_eq!(
+                super::is_cursor(&launcher),
+                expected,
+                "unexpected result for a manifest naming {product}"
+            );
+        }
+
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn ignores_cursors_bundled_skill_directory() {
+        // Cursor ships its own skills in `~/.cursor/skills-cursor`, which is
+        // not one of the skill roots Cursor documents. Reporting it would add
+        // the same vendor defaults to every device in a fleet.
+        assert!(
+            !skill_roots()
+                .iter()
+                .any(|root: &PathBuf| root.ends_with(".cursor/skills-cursor"))
+        );
+    }
+}

--- a/crates/agent/src/provider/cursor/integration_tests.rs
+++ b/crates/agent/src/provider/cursor/integration_tests.rs
@@ -39,7 +39,7 @@ async fn headless_discovery() -> anyhow::Result<()> {
         info!("Checking Cursor discovery and VS Code fork rejection");
         let output = container.exec(&["curl", "--fail", "--silent", "--unix-socket", DEFAULT_SOCKET_PATH, "http://localhost/v1/discovery"]).await?;
         let discovery: Discovery = serde_json::from_str(&output)?;
-        ensure!(!discovery.agents.iter().any(|agent| agent.kind == "vscode"), "Cursor was also reported as VS Code");
+        ensure!(!discovery.agents.iter().any(|agent| agent.kind == "vscode"), "Cursor was also reported as VS Code; discovery: {output}");
         let agent = discovery.agents.iter().find(|agent| agent.kind == "cursor").context("Cursor was not discovered")?;
         ensure!(agent.version.as_deref() == Some(VERSION), "incorrect discovered version: {:?}", agent.version);
         ensure!(agent.mcp_servers.len() == 2, "unexpected MCP servers: {:?}", agent.mcp_servers);

--- a/crates/agent/src/provider/cursor/integration_tests.rs
+++ b/crates/agent/src/provider/cursor/integration_tests.rs
@@ -1,0 +1,63 @@
+use std::time::Duration;
+
+use agentdesktop_core::{DEFAULT_SOCKET_PATH, model::Discovery};
+use anyhow::{Context, ensure};
+use tracing::info;
+
+use crate::common::Container;
+
+const VERSION: &str = "3.19.13";
+const USER_MCP: &str = "/home/tester/.cursor/mcp.json";
+const WORKSPACE_MCP: &str = "/home/tester/project/.cursor/mcp.json";
+const USER_SKILL: &str = "/home/tester/.cursor/skills/test/SKILL.md";
+const WORKSPACE_SKILL: &str = "/home/tester/project/.cursor/skills/test/SKILL.md";
+const VENDOR_SKILL: &str = "/home/tester/.cursor/skills-cursor/vendor/SKILL.md";
+
+#[tokio::test]
+async fn headless_discovery() -> anyhow::Result<()> {
+    Container::run("cursor", "crates/agent/src/provider/cursor/testdata/Dockerfile", async |container| {
+        info!("Checking installed Cursor CLI without a display");
+        let version = container.exec_as("tester", &["cursor", "--version"], Duration::from_secs(15)).await?;
+        ensure!(version.lines().next() == Some(VERSION), "unexpected Cursor version: {version}");
+        // A code alias to the real Cursor launcher must not be reported as VS Code.
+        container.exec(&["sh", "-c", "test -f \"$(command -v code)\""]).await?;
+        let files = [
+            (USER_MCP, r#"{"mcpServers":{"user-docs":{"type":"streamable-http","url":"https://example.test/mcp","headers":{"Authorization":"fixture-secret"}}}}"#),
+            (WORKSPACE_MCP, r#"{
+                // Cursor accepts the VS Code MCP schema too.
+                "servers": { "workspace-local": { "command": "fixture-command", "args": ["fixture-secret"], "env": { "TOKEN": "fixture-secret" }, "disabled": true, }, },
+            }"#),
+            (USER_SKILL, "---\nname: user-skill\n---\nfixture-body-not-metadata\n"),
+            (WORKSPACE_SKILL, "---\nname: workspace-skill\n---\nfixture-body-not-metadata\n"),
+            (VENDOR_SKILL, "---\nname: vendor-skill\n---\nVendor default\n"),
+        ];
+        for (path, contents) in files { container.write(path, contents).await?; }
+        container.write("/tmp/agentdesktop.yaml", "programs: {}\n").await?;
+        container.start_process("daemon", &["agentdesktop", "daemon", "--config", "/tmp/agentdesktop.yaml"]).await?;
+        container.wait_ready(&["agentdesktop", "status"]).await?;
+
+        info!("Checking Cursor discovery and VS Code fork rejection");
+        let output = container.exec(&["curl", "--fail", "--silent", "--unix-socket", DEFAULT_SOCKET_PATH, "http://localhost/v1/discovery"]).await?;
+        let discovery: Discovery = serde_json::from_str(&output)?;
+        ensure!(!discovery.agents.iter().any(|agent| agent.kind == "vscode"), "Cursor was also reported as VS Code");
+        let agent = discovery.agents.iter().find(|agent| agent.kind == "cursor").context("Cursor was not discovered")?;
+        ensure!(agent.version.as_deref() == Some(VERSION), "incorrect discovered version: {:?}", agent.version);
+        ensure!(agent.mcp_servers.len() == 2, "unexpected MCP servers: {:?}", agent.mcp_servers);
+        for (name, transport, enabled, source, command, url) in [
+            ("user-docs", "http", true, USER_MCP, None, Some("https://example.test/mcp")),
+            ("workspace-local", "stdio", false, WORKSPACE_MCP, Some("fixture-command"), None),
+        ] {
+            let server = agent.mcp_servers.iter().find(|server| server.name == name).with_context(|| format!("missing MCP server {name}"))?;
+            ensure!(server.transport == transport && server.enabled == enabled && server.source == std::path::Path::new(source)
+                && server.command.as_deref() == command && server.url.as_deref() == url, "incorrect MCP discovery: {server:?}");
+        }
+        ensure!(agent.skills.len() == 2, "unexpected skills (vendor defaults must be omitted): {:?}", agent.skills);
+        for (path, name) in [(USER_SKILL, "user-skill"), (WORKSPACE_SKILL, "workspace-skill")] {
+            ensure!(agent.skills.iter().any(|skill| skill.path == std::path::Path::new(path) && skill.front_matter.get("name").and_then(|value| value.as_str()) == Some(name)), "missing skill {name}");
+        }
+        ensure!(!output.contains("fixture-secret") && !output.contains("fixture-body-not-metadata"), "discovery exposed non-metadata content");
+        container.stop_process("daemon").await?;
+        for (path, contents) in files { ensure!(container.read(path).await? == contents, "discovery changed {path}"); }
+        Ok(())
+    }).await
+}

--- a/crates/agent/src/provider/cursor/mod.rs
+++ b/crates/agent/src/provider/cursor/mod.rs
@@ -1,0 +1,22 @@
+use agentdesktop_core::model::Discovery;
+
+use super::Provider;
+
+mod discovery;
+
+pub struct Cursor;
+
+impl Cursor {
+    pub const ID: &'static str = "cursor";
+    pub const DISPLAY_NAME: &'static str = "Cursor";
+}
+
+#[async_trait::async_trait]
+impl Provider for Cursor {
+    async fn discover(&self) -> Discovery {
+        Discovery {
+            agents: discovery::discover().into_iter().collect(),
+            model_runtimes: Vec::new(),
+        }
+    }
+}

--- a/crates/agent/src/provider/cursor/testdata/Dockerfile
+++ b/crates/agent/src/provider/cursor/testdata/Dockerfile
@@ -1,0 +1,20 @@
+ARG BASE_IMAGE
+FROM ${BASE_IMAGE}
+ARG CURSOR_VERSION=3.19.13
+ARG CURSOR_COMMIT=dd066f332fcea7382764400fde902f61920648d5
+# The CLI links Electron libraries but does not need a display server.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        libnss3 libatk-bridge2.0-0 libgtk-3-0 libgbm1 libasound2t64 \
+    && rm -rf /var/lib/apt/lists/* \
+    && groupadd --system agentdesktop \
+    && useradd --create-home --user-group --groups agentdesktop tester
+RUN case "$(uname -m)" in x86_64) platform=x64; arch=amd64 ;; aarch64) platform=arm64; arch=arm64 ;; *) exit 1 ;; esac \
+    && curl -fsSL "https://downloads.cursor.com/production/${CURSOR_COMMIT}/linux/${platform}/deb/${arch}/deb/cursor_${CURSOR_VERSION}_${arch}.deb" -o /tmp/cursor.deb \
+    && dpkg-deb -x /tmp/cursor.deb / \
+    && rm /tmp/cursor.deb \
+    && ln -s cursor /usr/share/cursor/bin/code
+# Simulate Cursor being installed as the user's code command as well.
+ENV HOME=/home/tester \
+    PATH=/usr/share/cursor/bin:$PATH
+WORKDIR /home/tester/project
+CMD ["sleep", "infinity"]

--- a/crates/agent/src/provider/metadata.rs
+++ b/crates/agent/src/provider/metadata.rs
@@ -14,8 +14,27 @@ struct PackageMetadata {
 }
 
 pub(super) fn find_in_path(name: &str) -> Option<PathBuf> {
-    let path = env::var_os("PATH")?;
-    find_in_directories(name, env::split_paths(&path))
+    find_all_in_path(name).into_iter().next()
+}
+
+/// Every match for `name` on `PATH`, in `PATH` order.
+///
+/// Discovery for a tool with editor forks needs to look past the first hit,
+/// because the fork's launcher can shadow the real one.
+pub(super) fn find_all_in_path(name: &str) -> Vec<PathBuf> {
+    let Some(path) = env::var_os("PATH") else {
+        return Vec::new();
+    };
+    let extensions = executable_extensions(name);
+    env::split_paths(&path)
+        .flat_map(|directory| {
+            extensions
+                .iter()
+                .map(|extension| directory.join(format!("{name}{extension}")))
+                .collect::<Vec<_>>()
+        })
+        .filter(|candidate| candidate.is_file())
+        .collect()
 }
 
 pub(super) fn find_executable(
@@ -25,19 +44,6 @@ pub(super) fn find_executable(
     find_in_path(name).or_else(|| {
         additional_candidates
             .into_iter()
-            .find(|candidate| candidate.is_file())
-    })
-}
-
-fn find_in_directories(
-    name: &str,
-    directories: impl IntoIterator<Item = PathBuf>,
-) -> Option<PathBuf> {
-    let extensions = executable_extensions(name);
-    directories.into_iter().find_map(|directory| {
-        extensions
-            .iter()
-            .map(|extension| directory.join(format!("{name}{extension}")))
             .find(|candidate| candidate.is_file())
     })
 }
@@ -82,13 +88,39 @@ pub(super) fn version_after_component(executable: &Path, component: &str) -> Opt
     components.next()?.as_os_str().to_str().map(str::to_owned)
 }
 
-pub(super) fn json_version(path: &Path) -> Option<String> {
-    json_package_metadata(path).map(|metadata| metadata.version)
-}
-
 pub(super) fn json_package_version(path: &Path, expected_name: &str) -> Option<String> {
     let metadata = json_package_metadata(path)?;
     (metadata.name.as_deref() == Some(expected_name)).then_some(metadata.version)
+}
+
+pub(super) fn json_package_name(path: &Path) -> Option<String> {
+    json_package_metadata(path)?.name
+}
+
+/// `package.json` manifests that may describe the packaged application an
+/// executable belongs to.
+///
+/// Electron editors keep the manifest a fixed number of directories above their
+/// launcher, and the launcher on `PATH` is frequently a symlink into the
+/// install root.
+pub(super) fn packaged_manifest_candidates(executable: &Path) -> Vec<PathBuf> {
+    let mut candidates = BTreeSet::new();
+    for executable in [
+        Some(executable.to_path_buf()),
+        executable.canonicalize().ok(),
+    ]
+    .into_iter()
+    .flatten()
+    {
+        if let Some(directory) = executable.parent() {
+            candidates.insert(directory.join("resources/app/package.json"));
+            candidates.insert(directory.join("../resources/app/package.json"));
+            // macOS application bundles keep the manifest directly above `bin`.
+            candidates.insert(directory.join("../package.json"));
+            candidates.insert(directory.join("../../package.json"));
+        }
+    }
+    candidates.into_iter().collect()
 }
 
 fn json_package_metadata(path: &Path) -> Option<PackageMetadata> {

--- a/crates/agent/src/provider/mod.rs
+++ b/crates/agent/src/provider/mod.rs
@@ -11,6 +11,7 @@ use crate::reconcile::ReconcilePlan;
 pub mod claude_code;
 pub mod claude_desktop;
 pub mod codex;
+pub mod cursor;
 mod json_merge;
 mod metadata;
 pub mod ollama;

--- a/crates/agent/src/provider/vscode/discovery.rs
+++ b/crates/agent/src/provider/vscode/discovery.rs
@@ -11,11 +11,21 @@ use serde_json::Value;
 
 use crate::provider::metadata;
 
+/// Product name recorded in Visual Studio Code's packaged `package.json`.
+const PRODUCT_NAME: &str = "Code";
+
 pub(super) fn discover() -> Option<Agent> {
-    let executable = metadata::find_executable("code", executable_candidates())?;
+    let executable = metadata::find_all_in_path("code")
+        .into_iter()
+        .chain(
+            executable_candidates()
+                .into_iter()
+                .filter(|candidate| candidate.is_file()),
+        )
+        .find(|candidate| is_visual_studio_code(candidate))?;
     let version = version_candidates(&executable)
         .into_iter()
-        .find_map(|path| metadata::json_version(&path));
+        .find_map(|path| metadata::json_package_version(&path, PRODUCT_NAME));
     Some(Agent {
         version,
         executable,
@@ -23,6 +33,20 @@ pub(super) fn discover() -> Option<Agent> {
         mcp_servers: discover_mcp_servers(),
         skills: metadata::discover_skills(skill_roots()),
     })
+}
+
+/// Visual Studio Code forks such as Cursor and Windsurf ship their own `code`
+/// launcher, so finding one on `PATH` does not prove it is Visual Studio Code.
+///
+/// A candidate is rejected only when its packaged manifest positively names a
+/// different product, so a fork's launcher on `PATH` is skipped in favour of a
+/// real install. Layouts that expose no manifest are still accepted, which
+/// keeps detection working for packaging this module does not model.
+fn is_visual_studio_code(executable: &Path) -> bool {
+    metadata::packaged_manifest_candidates(executable)
+        .into_iter()
+        .find_map(|path| metadata::json_package_name(&path))
+        .is_none_or(|name| name == PRODUCT_NAME)
 }
 
 fn discover_mcp_servers() -> Vec<McpServer> {
@@ -70,7 +94,7 @@ fn user_profile_root(home: &Path) -> PathBuf {
     home.join("AppData/Roaming/Code/User")
 }
 
-fn mcp_servers_from_json(path: &Path) -> Vec<McpServer> {
+pub(in crate::provider) fn mcp_servers_from_json(path: &Path) -> Vec<McpServer> {
     let Ok(contents) = fs::read_to_string(path) else {
         return Vec::new();
     };
@@ -80,7 +104,10 @@ fn mcp_servers_from_json(path: &Path) -> Vec<McpServer> {
     mcp_servers_from_value(&document, path)
 }
 
-fn mcp_servers_from_value(document: &Value, source: &Path) -> Vec<McpServer> {
+pub(in crate::provider) fn mcp_servers_from_value(
+    document: &Value,
+    source: &Path,
+) -> Vec<McpServer> {
     let Some(servers) = document
         .get("servers")
         .or_else(|| document.get("mcpServers"))
@@ -173,20 +200,9 @@ fn executable_candidates() -> Vec<PathBuf> {
 }
 
 fn version_candidates(executable: &Path) -> Vec<PathBuf> {
-    let mut candidates = BTreeSet::new();
-    for executable in [
-        Some(executable.to_path_buf()),
-        executable.canonicalize().ok(),
-    ]
-    .into_iter()
-    .flatten()
-    {
-        if let Some(directory) = executable.parent() {
-            candidates.insert(directory.join("resources/app/package.json"));
-            candidates.insert(directory.join("../resources/app/package.json"));
-            candidates.insert(directory.join("../../package.json"));
-        }
-    }
+    let mut candidates: BTreeSet<PathBuf> = metadata::packaged_manifest_candidates(executable)
+        .into_iter()
+        .collect();
     candidates.extend([
         PathBuf::from("/usr/share/code/resources/app/package.json"),
         PathBuf::from("/usr/lib/code/resources/app/package.json"),
@@ -208,7 +224,65 @@ mod tests {
 
     use serde_json::json;
 
-    use super::{mcp_servers_from_json, mcp_servers_from_value};
+    use super::{is_visual_studio_code, mcp_servers_from_json, mcp_servers_from_value};
+
+    /// Builds an Electron editor install tree and returns its `bin` launcher.
+    ///
+    /// `manifest` is the manifest location relative to the install root:
+    /// `resources/app/package.json` matches Linux and Windows packaging, and
+    /// `package.json` matches a macOS application bundle, where `bin` sits
+    /// beside the manifest rather than below `resources/app`.
+    fn packaged_editor(name: &str, product: &str, manifest: &str) -> std::path::PathBuf {
+        let root = std::env::temp_dir().join(format!(
+            "agentdesktop-{name}-{}-{:?}",
+            std::process::id(),
+            std::thread::current().id()
+        ));
+        let _ = fs::remove_dir_all(&root);
+        let manifest = root.join(manifest);
+        fs::create_dir_all(manifest.parent().unwrap()).unwrap();
+        fs::create_dir_all(root.join("bin")).unwrap();
+        fs::write(
+            &manifest,
+            json!({ "name": product, "version": "1.2.3" }).to_string(),
+        )
+        .unwrap();
+        let launcher = root.join("bin/code");
+        fs::write(&launcher, "").unwrap();
+        launcher
+    }
+
+    #[test]
+    fn rejects_a_code_launcher_belonging_to_a_fork() {
+        let launcher = packaged_editor("fork", "Cursor", "resources/app/package.json");
+        assert!(!is_visual_studio_code(&launcher));
+        let _ = fs::remove_dir_all(launcher.parent().unwrap().parent().unwrap());
+    }
+
+    #[test]
+    fn accepts_a_code_launcher_belonging_to_visual_studio_code() {
+        let launcher = packaged_editor("vscode", "Code", "resources/app/package.json");
+        assert!(is_visual_studio_code(&launcher));
+        let _ = fs::remove_dir_all(launcher.parent().unwrap().parent().unwrap());
+    }
+
+    /// The macOS bundle layout is the one that ships on this platform, so the
+    /// product check has to reach the manifest that sits above `bin`.
+    #[test]
+    fn reads_the_product_of_an_application_bundle_layout() {
+        let fork = packaged_editor("bundle-fork", "Cursor", "package.json");
+        assert!(!is_visual_studio_code(&fork));
+        let _ = fs::remove_dir_all(fork.parent().unwrap().parent().unwrap());
+
+        let genuine = packaged_editor("bundle-vscode", "Code", "package.json");
+        assert!(is_visual_studio_code(&genuine));
+        let _ = fs::remove_dir_all(genuine.parent().unwrap().parent().unwrap());
+    }
+
+    #[test]
+    fn accepts_an_install_layout_without_a_manifest() {
+        assert!(is_visual_studio_code(Path::new("/usr/bin/code")));
+    }
 
     #[cfg(target_os = "macos")]
     #[test]

--- a/crates/agent/src/provider/vscode/discovery.rs
+++ b/crates/agent/src/provider/vscode/discovery.rs
@@ -43,10 +43,14 @@ pub(super) fn discover() -> Option<Agent> {
 /// real install. Layouts that expose no manifest are still accepted, which
 /// keeps detection working for packaging this module does not model.
 fn is_visual_studio_code(executable: &Path) -> bool {
-    metadata::packaged_manifest_candidates(executable)
+    let manifest = metadata::packaged_manifest_candidates(executable)
         .into_iter()
-        .find_map(|path| metadata::json_package_name(&path))
-        .is_none_or(|name| name == PRODUCT_NAME)
+        .find_map(|path| metadata::json_package_name(&path).map(|name| (path, name)));
+    let accepted = manifest
+        .as_ref()
+        .is_none_or(|(_, name)| name == PRODUCT_NAME);
+    tracing::debug!(executable = %executable.display(), ?manifest, accepted, "Checking VS Code candidate");
+    accepted
 }
 
 fn discover_mcp_servers() -> Vec<McpServer> {

--- a/crates/agent/src/reconcile/mod.rs
+++ b/crates/agent/src/reconcile/mod.rs
@@ -4,7 +4,7 @@ pub use plan::ReconcilePlan;
 
 use crate::provider::{
     Provider, ReconcileContext, claude_code::ClaudeCode, claude_desktop::ClaudeDesktop,
-    codex::Codex, ollama::Ollama, opencode::OpenCode, vscode::VsCode,
+    codex::Codex, cursor::Cursor, ollama::Ollama, opencode::OpenCode, vscode::VsCode,
 };
 use agentdesktop_core::{config::DaemonConfig, model::Discovery};
 use serde_json::Value;
@@ -67,6 +67,7 @@ impl Reconciler {
                     plugin_path: open_code_plugin_path,
                 }),
                 Box::new(VsCode),
+                Box::new(Cursor),
                 Box::new(Ollama),
             ]),
         }

--- a/crates/agent/tests/integration.rs
+++ b/crates/agent/tests/integration.rs
@@ -11,3 +11,6 @@ mod opencode;
 
 #[path = "../src/provider/vscode/integration_tests.rs"]
 mod vscode;
+
+#[path = "../src/provider/cursor/integration_tests.rs"]
+mod cursor;

--- a/frontend/ui/src/tools.tsx
+++ b/frontend/ui/src/tools.tsx
@@ -60,6 +60,7 @@ export function friendlyTool(kind: string) {
     "claude-desktop": "Claude Desktop",
     opencode: "OpenCode",
     vscode: "VS Code",
+    cursor: "Cursor",
   };
   return names[kind.toLowerCase()] ?? kind;
 }


### PR DESCRIPTION
Adds Cursor discovery, and fixes a related misidentification in VS Code
discovery that adding Cursor exposes.

Fixes #21.

## Cursor discovery

`crates/agent/src/discovery/cursor.rs` follows the existing per-tool module
shape:

- **Executable** — `PATH`, plus the macOS app bundle, the Linux `deb`/`opt`
  install roots, and the Windows `Programs\Cursor` layout.
- **Version** — read from the packaged `package.json`, name-checked against
  `Cursor` so a different editor's manifest cannot be misread.
- **MCP servers** — user-level `~/.cursor/mcp.json` and project-level
  `.cursor/mcp.json`. Cursor is a VS Code fork and uses the same schema, so
  this reuses the existing VS Code parser rather than copying it.
- **Skills** — the roots Cursor documents: `.cursor/skills`, `.agents/skills`,
  and the `.claude/skills` / `.codex/skills` directories Cursor reads for
  compatibility, at both project and user level.

Managed configuration and sandbox policy are not included; this is discovery
and inventory only, matching the current VS Code row in the README table.

## VS Code misidentification

`vscode::discover()` accepted any `code` launcher on `PATH` and read its
version through `metadata::json_version`, which does not check the manifest's
product name. Cursor and other VS Code forks ship their own `code` launcher,
so on a machine where a fork's launcher comes first on `PATH`, agentdesktop
would report an agent of kind `vscode` carrying the fork's version number.

Discovery now walks its candidates and skips any whose packaged manifest names
a different product, so a fork's launcher is passed over in favour of a real
VS Code install rather than ending the search. A candidate with no manifest is
still accepted, so install layouts this module does not model (snap, and
others) keep working as before.

`metadata::json_version` had no remaining callers after this and was removed.

## Validation

`make test`, `make check`, `make generate-schema` (no diff), and `pnpm check`
all pass locally on macOS.

Verified against a real install — Cursor 3.9.16 and VS Code 1.132.0 side by
side on the same machine, each resolving to its own executable and version,
with Cursor's `~/.cursor/mcp.json` server appearing in its inventory:

```
CURSOR: "/Applications/Cursor.app/Contents/Resources/app/bin/cursor" "3.9.16"
VSCODE: "/Applications/Visual Studio Code.app/Contents/Resources/app/bin/code" "1.132.0"
```

New unit tests cover the Cursor MCP schema, the skill roots, and the three
launcher-identity cases (fork rejected, VS Code accepted, no manifest
accepted).

## One thing worth your call

Cursor ships ~25 of its own skills in `~/.cursor/skills-cursor`. That is not
one of the skill roots Cursor documents, so I left it out — otherwise the same
vendor defaults land in every device's inventory. Happy to include it if you'd
rather the inventory show everything a tool can load.

Related: `codex.rs` already picks up `~/.codex/skills/.system`, which is the
same category of bundled-vendor skill. I left that alone rather than change
behaviour outside this issue, but flagging it in case you want consistency
either way.

I also did not add a Cursor icon to `frontend/ui/src/assets` — it falls back to
the generic tool icon. Happy to add one, but third-party logo assets seemed
like your call rather than mine.


## Update after review

Review flagged that an unrelated `cursor` on `PATH` could be reported carrying a
version read from a real Cursor install elsewhere. Chasing it turned up the
larger problem behind it: none of the manifest candidates matched the macOS
application bundle layout, where the manifest sits directly above `bin` rather
than under `resources/app`. That is the layout both editors ship on macOS, so
the product check could never reach a manifest there and the fork rejection this
PR is built around was inert on that platform. The tests passed because they
modelled a `resources/app` tree macOS does not use.

Manifest lookup now covers the bundle layout, versions are read only from the
discovered executable's own manifest, discovery walks every `PATH` match instead
of stopping at the first rejected one, and the tests cover both real layouts.

**Still worth your call:** a launcher with no manifest is accepted rather than
rejected, so Linux AppImage installs — which expose no manifest — keep being
discovered. That trades a possible false positive for avoiding a false negative.
Happy to invert it if you would rather miss AppImage installs than risk
reporting an unrelated `cursor` binary.
