### PR TITLE
feat: update menu id name

### DIFF
--- a/crates/agentdesktop/src/main.rs
+++ b/crates/agentdesktop/src/main.rs
@@ -602,7 +602,7 @@ fn run_desktop() -> anyhow::Result<()> {
             });
 
             let open =
-                MenuItem::with_id(app, OPEN_MENU_ID, "Open Agent Desktop", true, None::<&str>)?;
+                MenuItem::with_id(app, OPEN_MENU_ID, "Open agentdesktop", true, None::<&str>)?;
             let separator = PredefinedMenuItem::separator(app)?;
             let status = MenuItem::with_id(app, "status", "Checking daemon…", false, None::<&str>)?;
             let quit = MenuItem::with_id(app, QUIT_MENU_ID, "Quit", true, None::<&str>)?;


### PR DESCRIPTION
The current menu ID name looks like the below:

<img width="198" height="135" alt="image" src="https://github.com/user-attachments/assets/28cedf4b-a26d-4e43-be60-690e1873eea2" />

It should be lowercase "agentdesktop" without spaces.