### PR TITLE
fix(macos): write Claude Desktop managed settings as a property list

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -62,6 +62,7 @@ dependencies = [
  "libc",
  "memchr",
  "open",
+ "plist",
  "rand",
  "rcgen",
  "reqwest",

--- a/crates/agent/Cargo.toml
+++ b/crates/agent/Cargo.toml
@@ -63,6 +63,7 @@ libc.workspace = true
 [target.'cfg(target_os = "macos")'.dependencies]
 apple-native-keyring-store.workspace = true
 keyring-core.workspace = true
+plist = "1.10"
 
 [target.'cfg(windows)'.dependencies]
 keyring.workspace = true

--- a/crates/agent/src/provider/claude_desktop/mod.rs
+++ b/crates/agent/src/provider/claude_desktop/mod.rs
@@ -41,7 +41,7 @@ impl Provider for ClaudeDesktop {
     fn plan(&self, ctx: &ReconcileContext, config: &DaemonConfig) -> anyhow::Result<ReconcilePlan> {
         if ctx.merge_user_settings && config.programs.claude_desktop.is_some() {
             anyhow::bail!(
-                "Claude Desktop does not read inference settings from its user preferences; remove programs.claudeDesktop or run Agentdesktop without --user as root so it can manage /etc/claude-desktop/managed-settings.json"
+                "Claude Desktop does not read inference settings from its user preferences; remove programs.claudeDesktop or run Agentdesktop without --user as root so it can manage its Claude Desktop managed settings"
             );
         }
         let configured = config.programs.claude_desktop.as_ref().map(|provider| {
@@ -66,8 +66,22 @@ impl Provider for ClaudeDesktop {
 }
 
 /// Returns Claude Desktop's system-managed settings path.
+#[cfg(not(target_os = "macos"))]
 pub fn default_claude_desktop_managed_settings_path() -> PathBuf {
     PathBuf::from("/etc/claude-desktop/managed-settings.json")
+}
+
+/// Returns Claude Desktop's system-managed settings path.
+///
+/// Claude Desktop on macOS reads its managed configuration the same way as any other
+/// managed macOS application: via `CFPreferencesCopyAppValue` against the
+/// `com.anthropic.claudefordesktop` preference domain, backed by a property list under
+/// `/Library/Managed Preferences/`. It never reads a JSON file under `/etc`, so this must
+/// be a `.plist` and the reconciler must write it with `plist::to_writer_xml` — see
+/// `reconcile::serialize_managed_settings`.
+#[cfg(target_os = "macos")]
+pub fn default_claude_desktop_managed_settings_path() -> PathBuf {
+    PathBuf::from("/Library/Managed Preferences/com.anthropic.claudefordesktop.plist")
 }
 
 /// Returns the path of Agentdesktop's Claude Desktop credential helper.

--- a/crates/agent/src/provider/claude_desktop/reconcile.rs
+++ b/crates/agent/src/provider/claude_desktop/reconcile.rs
@@ -70,9 +70,7 @@ pub(super) fn plan(
             "Claude Desktop settings cannot be applied to its user preferences; use system-managed settings"
         );
     }
-    let mut contents = serde_json::to_vec_pretty(&settings)
-        .context("serialize Claude Desktop managed settings")?;
-    contents.push(b'\n');
+    let contents = serialize_managed_settings(&settings)?;
     write_owned(
         settings_path,
         &settings_owner,
@@ -81,6 +79,25 @@ pub(super) fn plan(
         "managed settings",
         plan,
     )
+}
+
+/// Serializes managed settings into the format Claude Desktop actually reads on this
+/// platform. On macOS that's a property list — `CFPreferencesCopyAppValue` never consults
+/// a JSON file — everywhere else it's pretty-printed JSON.
+#[cfg(target_os = "macos")]
+fn serialize_managed_settings(settings: &Value) -> anyhow::Result<Vec<u8>> {
+    let mut contents = Vec::new();
+    plist::to_writer_xml(&mut contents, settings)
+        .context("serialize Claude Desktop managed settings as a property list")?;
+    Ok(contents)
+}
+
+#[cfg(not(target_os = "macos"))]
+fn serialize_managed_settings(settings: &Value) -> anyhow::Result<Vec<u8>> {
+    let mut contents = serde_json::to_vec_pretty(settings)
+        .context("serialize Claude Desktop managed settings")?;
+    contents.push(b'\n');
+    Ok(contents)
 }
 
 fn credential_helper_contents(credential_binary: &Path, socket: &Path) -> anyhow::Result<Vec<u8>> {
@@ -268,6 +285,8 @@ mod tests {
         batch_quote, managed_settings, posix_credential_helper_contents,
         windows_credential_helper_contents,
     };
+    #[cfg(target_os = "macos")]
+    use super::serialize_managed_settings;
     use agentdesktop_core::config::parse_daemon;
 
     #[test]
@@ -324,5 +343,45 @@ programs:
         assert_eq!(settings["isLocalDevMcpEnabled"], true);
         assert_eq!(settings["inferenceProvider"], "gateway");
         assert_eq!(settings["inferenceCredentialHelper"], "/helper");
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn macos_serializes_managed_settings_as_a_property_list() {
+        let config = parse_daemon(
+            r#"
+llmGateway:
+  url: https://gateway.example.com
+  authentication:
+    type: controllerJwt
+    audience: agentgateway
+    allowedClientIds: [claude-desktop]
+programs:
+  claudeDesktop: {}
+"#,
+        )
+        .unwrap();
+        let desktop = config.programs.claude_desktop.as_ref().unwrap();
+        let settings =
+            managed_settings(desktop, config.llm_gateway.as_ref(), Path::new("/helper")).unwrap();
+
+        let contents = serialize_managed_settings(&settings).expect("plist serializes");
+        assert!(
+            contents.starts_with(b"<?xml"),
+            "expected XML property list, got {:?}",
+            String::from_utf8_lossy(&contents)
+        );
+
+        let parsed: plist::Value = plist::from_bytes(&contents).expect("plist parses back");
+        let dict = parsed.as_dictionary().expect("top-level dictionary");
+        assert_eq!(
+            dict.get("inferenceProvider").and_then(plist::Value::as_string),
+            Some("gateway")
+        );
+        assert_eq!(
+            dict.get("inferenceGatewayBaseUrl")
+                .and_then(plist::Value::as_string),
+            Some("https://gateway.example.com/")
+        );
     }
 }

--- a/crates/agent/src/reconcile/mod.rs
+++ b/crates/agent/src/reconcile/mod.rs
@@ -283,7 +283,7 @@ programs:
         assert!(
             error
                 .to_string()
-                .contains("/etc/claude-desktop/managed-settings.json")
+                .contains("Claude Desktop managed settings")
         );
         assert!(!root.exists(), "preflight failure must not write any files");
     }


### PR DESCRIPTION
Fixes #92

Claude Desktop on macOS reads its managed configuration via `CFPreferencesCopyAppValue` against the `com.anthropic.claudefordesktop` preference domain, backed by a property list under `/Library/Managed Preferences/`. It never reads a JSON file under `/etc` — that path is documented in the app's own bundle as Linux-only ("administrators can provision settings in a root-owned `/etc/claude-desktop/managed-settings.json`, validated against the same schema as the macOS and Windows sources").

`default_claude_desktop_managed_settings_path()` had no macOS override and fell through to the Linux path, so the daemon was writing JSON settings the app could never read on macOS.

## Changes

- Add a `#[cfg(target_os = "macos")]` override for `default_claude_desktop_managed_settings_path()` returning `/Library/Managed Preferences/com.anthropic.claudefordesktop.plist`
- Split serialization in `claude_desktop::apply()` by platform: `plist::to_writer_xml` on macOS, the existing pretty-printed JSON everywhere else
- Add `plist` as a macOS-only dependency to `crates/agent` (mirroring how `crates/agentdesktop` already depends on it)
- Add a macOS test verifying the plist round-trips through `plist::from_bytes` with the expected keys
- Soften a bail message that hardcoded the `/etc` path, since it's no longer accurate on macOS

## Verification

- `cargo test -p agentdesktop-agent` — 18/18 pass, including the new macOS plist test
- `cargo check --workspace` — clean
- Built and installed the patched daemon locally (macOS, arm64): confirmed the daemon writes a valid plist to `/Library/Managed Preferences/com.anthropic.claudefordesktop.plist` (`plutil -lint` passes), and Claude Desktop's "Configure third-party inference" panel picks up the gateway settings from it after a relaunch — previously it always displayed blank/consumer sign-in, since it had nothing to read.